### PR TITLE
feat: added connected address to web3modal hook

### DIFF
--- a/src/hooks/useWeb3Modal.ts
+++ b/src/hooks/useWeb3Modal.ts
@@ -15,5 +15,6 @@ export function useWeb3Modal() {
     close: ModalCtrl.close,
     provider: clientState.initialized ? ClientCtrl.provider() : undefined,
     isConnected: accountState.isConnected,
+    address: accountState.address,
   };
 }


### PR DESCRIPTION
## Summary
* Added `address` prop in `useWeb3Modal` hook to show the connected address when connected

Updated docs:
- [ ] https://github.com/WalletConnect/walletconnect-docs/pull/702

## Solves
https://github.com/WalletConnect/web3modal-react-native/issues/33
https://github.com/orgs/WalletConnect/discussions/2442