### PR TITLE
chore: added issue template and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+
+name: 🐛 Bug Report
+description: Report a reproducible bug or regression in @web3modal/react-native.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide all the information requested. Issues that do not follow this format are likely to stall.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description of what the bug is. Include screenshots if needed. Test using the [latest SDK release](https://github.com/WalletConnect/web3modal-react-native/releases) to make sure your issue has not already been fixed.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Web3Modal SDK version
+      description: What is the latest version of @web3modal/react-native that this issue reproduces on?
+      placeholder: ex. 1.0.0-alpha.5
+    validations:
+      required: true
+  - type: textarea
+    id: react-native-info
+    attributes:
+      label: Output of `npx react-native info`
+      description: Run `npx react-native info` in your terminal, copy and paste the results here.
+    validations:
+      required: true
+  - type: checkboxes
+    id: expo
+    attributes:
+      label: Are you using Expo?
+      options:
+        - label: Im using Expo
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a detailed list of steps that reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Snack, code example, screenshot, or link to a repository
+      description: |
+        Please provide a Snack (https://snack.expo.dev/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+        You may provide a screenshot of the application if you think it is relevant to your bug report.
+        Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve
+        Please note that a reproducer is **mandatory**. Issues without reproducer are more likely to stall and will be closed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 📃 Documentation Issue
+      url: https://github.com/WalletConnect/walletconnect-docs/issues
+      about: Please report documentation issues in the Wallet Connect website repository.
+    - name: 🤔 Questions and Help
+      url: https://github.com/orgs/WalletConnect/discussions/categories/web3modal-sdk-support
+      about: Looking for help with your app? Please refer to the Wallet Connect community's support resources.
+    - name: 🚀 Discussions and Proposals
+      url: https://github.com/orgs/WalletConnect/discussions
+      about: Discuss the future of Web3Modal SDK in the Wallet Connect community's discussions and proposals repository.


### PR DESCRIPTION
## Summary
* Added a new issue template similar to [this template](https://github.com/facebook/react-native/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A&projects=&template=bug_report.yml)
* Added contact links similar to the bottom links of [this](https://github.com/facebook/react-native/issues/new/choose)


This same template will be added to [react-native-examples](https://github.com/WalletConnect/react-native-examples)