### PR TITLE
fix: clean pressed wallet if user press qr button

### DIFF
--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -82,6 +82,10 @@ export const ConnectionController = {
     state.pressedWallet = wallet;
   },
 
+  removePressedWallet() {
+    state.pressedWallet = undefined;
+  },
+
   setRecentWallets(wallets: ConnectionControllerState['recentWallets']) {
     state.recentWallets = wallets;
   },

--- a/packages/scaffold/src/views/w3m-all-wallets-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-all-wallets-view/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useWindowDimensions } from 'react-native';
-import { RouterController } from '@web3modal/core-react-native';
+import { ConnectionController, RouterController } from '@web3modal/core-react-native';
 import {
   CardSelectWidth,
   FlexView,
@@ -25,6 +25,11 @@ export function AllWalletsView() {
 
   const onInputChange = useDebounceCallback({ callback: setSearchQuery });
 
+  const onQrCodePress = () => {
+    ConnectionController.removePressedWallet();
+    RouterController.push('ConnectingWalletConnect');
+  };
+
   const headerTemplate = () => {
     return (
       <FlexView
@@ -40,7 +45,7 @@ export function AllWalletsView() {
           iconColor="accent-100"
           background
           size="lg"
-          onPress={() => RouterController.push('ConnectingWalletConnect')}
+          onPress={onQrCodePress}
           style={styles.icon}
         />
       </FlexView>


### PR DESCRIPTION
### Summary
* Clean `pressedWallet` if the user presses QR button in all wallets list