### PR TITLE
fix: improved page loading shimmer items

### DIFF
--- a/packages/core/src/controllers/ApiController.ts
+++ b/packages/core/src/controllers/ApiController.ts
@@ -18,7 +18,7 @@ import { OptionsController } from './OptionsController';
 // -- Helpers ------------------------------------------- //
 const baseUrl = CoreHelperUtil.getApiUrl();
 const api = new FetchUtil({ baseUrl });
-const defaultEntries = '100';
+const defaultEntries = '48';
 const recommendedEntries = '4';
 const sdkType = 'w3m';
 
@@ -190,7 +190,7 @@ export const ApiController = {
     state.count = count ?? 0;
   },
 
-  async fetchWallets({ page, entries }: Pick<ApiGetWalletsRequest, 'page' | 'entries'>) {
+  async fetchWallets({ page }: Pick<ApiGetWalletsRequest, 'page'>) {
     const { includeWalletIds, excludeWalletIds, featuredWalletIds } = OptionsController.state;
     const exclude = [
       ...state.installed.map(({ id }) => id),
@@ -204,7 +204,7 @@ export const ApiController = {
       params: {
         page: String(page),
         platform: this.platform(),
-        entries: String(entries ?? defaultEntries),
+        entries: String(defaultEntries),
         include: includeWalletIds?.join(','),
         exclude: exclude.join(',')
       }
@@ -229,7 +229,7 @@ export const ApiController = {
       params: {
         page: '1',
         platform: this.platform(),
-        entries: defaultEntries,
+        entries: String(defaultEntries),
         search,
         include: includeWalletIds?.join(','),
         exclude: excludeWalletIds?.join(',')

--- a/packages/core/src/controllers/ApiController.ts
+++ b/packages/core/src/controllers/ApiController.ts
@@ -18,7 +18,7 @@ import { OptionsController } from './OptionsController';
 // -- Helpers ------------------------------------------- //
 const baseUrl = CoreHelperUtil.getApiUrl();
 const api = new FetchUtil({ baseUrl });
-const entries = '100';
+const defaultEntries = '100';
 const recommendedEntries = '4';
 const sdkType = 'w3m';
 
@@ -190,7 +190,7 @@ export const ApiController = {
     state.count = count ?? 0;
   },
 
-  async fetchWallets({ page }: Pick<ApiGetWalletsRequest, 'page'>) {
+  async fetchWallets({ page, entries }: Pick<ApiGetWalletsRequest, 'page' | 'entries'>) {
     const { includeWalletIds, excludeWalletIds, featuredWalletIds } = OptionsController.state;
     const exclude = [
       ...state.installed.map(({ id }) => id),
@@ -204,7 +204,7 @@ export const ApiController = {
       params: {
         page: String(page),
         platform: this.platform(),
-        entries,
+        entries: String(entries ?? defaultEntries),
         include: includeWalletIds?.join(','),
         exclude: exclude.join(',')
       }
@@ -229,7 +229,7 @@ export const ApiController = {
       params: {
         page: '1',
         platform: this.platform(),
-        entries,
+        entries: defaultEntries,
         search,
         include: includeWalletIds?.join(','),
         exclude: excludeWalletIds?.join(',')

--- a/packages/core/src/utils/TypeUtils.ts
+++ b/packages/core/src/utils/TypeUtils.ts
@@ -54,7 +54,7 @@ export interface DataWallet {
 
 export interface ApiGetWalletsRequest {
   page: number;
-  entries?: number;
+  entries: number;
   search?: string;
   include?: string[];
   exclude?: string[];

--- a/packages/core/src/utils/TypeUtils.ts
+++ b/packages/core/src/utils/TypeUtils.ts
@@ -54,7 +54,7 @@ export interface DataWallet {
 
 export interface ApiGetWalletsRequest {
   page: number;
-  entries: number;
+  entries?: number;
   search?: string;
   include?: string[];
   exclude?: string[];

--- a/packages/scaffold/src/partials/w3m-all-wallets-search/index.tsx
+++ b/packages/scaffold/src/partials/w3m-all-wallets-search/index.tsx
@@ -103,6 +103,7 @@ export function AllWalletsSearch({ searchQuery, columns, gap = 0 }: AllWalletsSe
       contentContainerStyle={[styles.contentContainer, { gap }]}
       columnWrapperStyle={{ gap }}
       ListEmptyComponent={emptyTemplate()}
+      keyExtractor={item => item.id}
       getItemLayout={(_, index) => ({
         length: ITEM_HEIGHT,
         offset: ITEM_HEIGHT * index,

--- a/packages/ui/src/composites/wui-card-select/index.tsx
+++ b/packages/ui/src/composites/wui-card-select/index.tsx
@@ -71,4 +71,6 @@ function _CardSelect({
   );
 }
 
-export const CardSelect = memo(_CardSelect);
+export const CardSelect = memo(_CardSelect, (prevProps, nextProps) => {
+  return prevProps.name === nextProps.name;
+});


### PR DESCRIPTION
### Summary
* Adding loading items dynamically to wallet list

#### The issue:
The page loader needs to be dynamic to cover this cases:

<img height="400" src="https://github.com/WalletConnect/web3modal-react-native/assets/25931366/12f2c123-c420-4504-b7e0-971d4f77a30f" />

The length of the wallet list is dynamic because: 
* Items per row is dynamic based on screen width
* Preloaded wallets before opening "All wallets" view is also dynamic based on recommended, featured and installed wallets

So if i want to show a page loader at bottom, i need to fill the empty spaces in the row

#### The solution:
Calculate how many wallets i need to fill the gap, and add those items at the bottom of the list

### Screenshots

https://github.com/WalletConnect/web3modal-react-native/assets/25931366/a68cbd2c-85b0-4e62-9f76-58e90207410a

https://github.com/WalletConnect/web3modal-react-native/assets/25931366/8098c05b-32d0-417d-824c-f0898ffa7cad

