### PR TITLE
fix: clear linking if qr is pressed

### DIFF
--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -74,6 +74,10 @@ export const ConnectionController = {
     state.wcLinking = wcLinking;
   },
 
+  removeWcLinking() {
+    state.wcLinking = undefined;
+  },
+
   setWcError(wcError: ConnectionControllerState['wcError']) {
     state.wcError = wcError;
   },

--- a/packages/scaffold/src/views/w3m-all-wallets-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-all-wallets-view/index.tsx
@@ -27,6 +27,7 @@ export function AllWalletsView() {
 
   const onQrCodePress = () => {
     ConnectionController.removePressedWallet();
+    ConnectionController.removeWcLinking();
     RouterController.push('ConnectingWalletConnect');
   };
 


### PR DESCRIPTION
### Summary
* Fixed an issue when the user selects a wallet but then decides to connect using a QR code. Now the linking is cleared so the provider doesn't redirect to the wrong app