### PR TITLE
fix: using asyncstorage in connector

### DIFF
--- a/packages/wagmi/src/utils/defaultWagmiConfig.ts
+++ b/packages/wagmi/src/utils/defaultWagmiConfig.ts
@@ -1,7 +1,7 @@
 import { configureChains, createConfig, type Chain } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
-import { walletConnectProvider } from './provider';
 import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider';
+import { walletConnectProvider } from './provider';
 import { WalletConnectConnector } from '../connectors/WalletConnectConnector';
 
 export interface ConfigOptions {

--- a/packages/wagmi/src/utils/storageUtils.ts
+++ b/packages/wagmi/src/utils/storageUtils.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const StorageUtils = {
+  getItem: async <T>(key: string): Promise<T> => {
+    const item = await AsyncStorage.getItem(key);
+
+    return item ? JSON.parse(item) : undefined;
+  },
+  setItem: async <T>(key: string, value: T) => {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  },
+  removeItem: async (key: string) => {
+    await AsyncStorage.removeItem(key);
+  }
+};


### PR DESCRIPTION
### Summary
* Using asyncstorage in custom wagmi connector instead of `this.storage`

Note: Wagmi allows to setup a custom storage but apparently it doesn't support async functions.


### Related issues
https://github.com/WalletConnect/web3modal-react-native/issues/78