### PR TITLE
fix: disabled nativedriver for press animations

### DIFF
--- a/packages/ui/src/composites/wui-button/index.tsx
+++ b/packages/ui/src/composites/wui-button/index.tsx
@@ -55,7 +55,7 @@ export function Button({
   const onPressIn = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 1,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };
@@ -63,7 +63,7 @@ export function Button({
   const onPressOut = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };

--- a/packages/ui/src/composites/wui-chip/index.tsx
+++ b/packages/ui/src/composites/wui-chip/index.tsx
@@ -47,7 +47,7 @@ export function Chip({
   const onPressIn = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 1,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
     setPressed(true);
@@ -56,7 +56,7 @@ export function Chip({
   const onPressOut = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
     setPressed(false);

--- a/packages/ui/src/composites/wui-connect-button/index.tsx
+++ b/packages/ui/src/composites/wui-connect-button/index.tsx
@@ -40,7 +40,7 @@ export function ConnectButton({
   const onPressIn = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 1,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };
@@ -48,7 +48,7 @@ export function ConnectButton({
   const onPressOut = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };

--- a/packages/ui/src/composites/wui-network-button/index.tsx
+++ b/packages/ui/src/composites/wui-network-button/index.tsx
@@ -38,7 +38,7 @@ export function NetworkButton({
   const onPressIn = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 1,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };
@@ -46,7 +46,7 @@ export function NetworkButton({
   const onPressOut = () => {
     Animated.timing(colorAnimation.current, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: 200
     }).start();
   };

--- a/packages/ui/src/hooks/useAnimatedValue.ts
+++ b/packages/ui/src/hooks/useAnimatedValue.ts
@@ -1,13 +1,17 @@
 import { useCallback, useRef } from 'react';
 import { Animated } from 'react-native';
 
-function useAnimatedValue(startValue: string, endValue: string, duration?: number) {
+function useAnimatedValue<T extends string | number>(
+  startValue: T,
+  endValue: T,
+  duration?: number
+) {
   const valueRef = useRef(new Animated.Value(0));
 
   const setStartValue = useCallback(() => {
     Animated.timing(valueRef.current, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: duration || 200
     }).start();
   }, [valueRef, duration]);
@@ -15,14 +19,14 @@ function useAnimatedValue(startValue: string, endValue: string, duration?: numbe
   const setEndValue = useCallback(() => {
     Animated.timing(valueRef.current, {
       toValue: 1,
-      useNativeDriver: true,
+      useNativeDriver: false,
       duration: duration || 200
     }).start();
   }, [valueRef, duration]);
 
   const animatedValue = valueRef.current.interpolate({
     inputRange: [0, 1],
-    outputRange: [startValue, endValue]
+    outputRange: [startValue, endValue] as number[] | string[]
   });
 
   return { animatedValue, valueRef, setStartValue, setEndValue };


### PR DESCRIPTION
### Summary
* Background animations with `useNativeDriver: true` are not supported in 0.71 and below. Disabling `useNativeDriver` to accomplish desired effect. 

Animations with `useNativeDriver: false` execute on JS Thread but as this is a simple animation, it shouldn't cause performance issues.

In the near future i'll try to accomplish similar results using opacity with `useNativeDriver: true`, or change the effect to something different