### PR TITLE
Change account UI margin left

### DIFF
--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -24,7 +24,7 @@ export default StyleSheet.create({
     flexDirection: 'row',
     height: 32,
     paddingLeft: Spacing['3xs'],
-    paddingRight: Spacing.xs,
+    paddingRight: Spacing['3xs'],
     justifyContent: 'center',
     alignItems: 'center'
   },

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -24,7 +24,7 @@ export default StyleSheet.create({
     flexDirection: 'row',
     height: 32,
     paddingLeft: Spacing['3xs'],
-    paddingRight: Spacing['3xs'],
+    paddingRight: Spacing.xs,
     justifyContent: 'center',
     alignItems: 'center'
   },

--- a/packages/ui/src/composites/wui-account-button/styles.ts
+++ b/packages/ui/src/composites/wui-account-button/styles.ts
@@ -24,6 +24,7 @@ export default StyleSheet.create({
     flexDirection: 'row',
     height: 32,
     paddingLeft: Spacing['3xs'],
+    paddingRight: Spacing.xs,
     justifyContent: 'center',
     alignItems: 'center'
   },
@@ -34,7 +35,6 @@ export default StyleSheet.create({
     alignItems: 'center',
     paddingLeft: Spacing['3xs'],
     paddingRight: Spacing.xs,
-    marginLeft: Spacing.xs,
     borderRadius: 100,
     borderWidth: 1
   },


### PR DESCRIPTION
Account View with no Balance Shown had some UI discrepancies

#### Issue
<img height="900" src="https://github.com/WalletConnect/web3modal-react-native/assets/45455218/98605858-3277-40da-abcd-60628a609669" />



#### Solution
- Change the margin / padding
- Not sure if you want to keep it as passing(3xs) or normal xs

<img height="900" src="https://github.com/WalletConnect/web3modal-react-native/assets/45455218/aaf108f3-6828-4c39-80ca-5dc6cdf47da4" />
