### PR TITLE
fix: added installed wallets in total count

### DIFF
--- a/packages/core/src/controllers/ApiController.ts
+++ b/packages/core/src/controllers/ApiController.ts
@@ -107,11 +107,16 @@ export const ApiController = {
   },
 
   async fetchInstalledWallets() {
+    const { includeWalletIds } = OptionsController.state;
     const path = Platform.select({ default: 'getIosData', android: 'getAndroidData' });
-    const { data: walletData } = await api.get<ApiGetDataWalletsResponse>({
+    let { data: walletData } = await api.get<ApiGetDataWalletsResponse>({
       path,
       headers: ApiController._getApiHeaders()
     });
+
+    if (includeWalletIds?.length) {
+      walletData = walletData.filter(({ id }) => includeWalletIds.includes(id));
+    }
 
     const promises = walletData.map(async item => {
       return {

--- a/packages/scaffold/src/views/w3m-connect-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-connect-view/index.tsx
@@ -108,7 +108,8 @@ export function ConnectView() {
       return null;
     }
 
-    const label = count > 10 ? `${Math.floor(count / 10) * 10}+` : count;
+    const total = installed.length + count;
+    const label = total > 10 ? `${Math.floor(total / 10) * 10}+` : total;
 
     return (
       <ListWallet


### PR DESCRIPTION
### Summary
Added installed wallets in "All wallets" button count. Fixes edge case where includedWalletIds < 10 and those wallets are installed. Before the count was showing "0" despite there were wallets in the list


### Screenshots
testing with
```
includeWalletIds: [
    '1ae92b26df02f0abca6304df07debccd18262fdf5fe82daa81593582dac9a369',
    '4622a2b2d6af1c9844944291e5e7351a6aa24cd7b23099efac1b2fd875da31a0',
  ],
```

<img height="600" alt="Screenshot 2024-01-05 at 15 57 42" src="https://github.com/WalletConnect/web3modal-react-native/assets/25931366/9cdfa412-3aa6-4b55-aa81-e7ee05ca1746">

<img height="600" alt="Screenshot 2024-01-05 at 15 57 45" src="https://github.com/WalletConnect/web3modal-react-native/assets/25931366/3c8bf8e6-6fd1-4360-a6dc-978f25ad6e43">