### PR TITLE
fix: compare connector type instead of id

### DIFF
--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -77,7 +77,9 @@ export class Web3Modal extends Web3ModalScaffold {
 
       async getApprovedCaipNetworksData() {
         const walletChoice = await StorageUtil.getConnectedConnector();
-        if (walletChoice?.includes(ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID)) {
+        const walletConnectType =
+          PresetsUtil.ConnectorTypesMap[ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID];
+        if (walletChoice?.includes(walletConnectType)) {
           const connector = wagmiConfig.connectors.find(
             c => c.id === ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID
           );


### PR DESCRIPTION
### Summary
* Compare connector types instead of the id. This issue was causing not to go back automatically to the profile view after switching the network with some wallets