### PR TITLE
chore: bump ethers5 to v1.2.0-alpha.1

### DIFF
--- a/.changeset/curvy-toys-press.md
+++ b/.changeset/curvy-toys-press.md
@@ -1,0 +1,5 @@
+---
+'@web3modal/ethers5-react-native': patch
+---
+
+added ethereum-provider as a dependency

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@apps/gallery": "1.0.4",
+    "@apps/native": "1.0.4",
+    "@apps/native-cli": "1.0.4",
+    "@web3modal/coinbase-ethers-react-native": "1.2.0-alpha.0",
+    "@web3modal/coinbase-wagmi-react-native": "1.2.0",
+    "@web3modal/core-react-native": "1.2.0",
+    "@web3modal/ethers5-react-native": "1.2.0-alpha.0",
+    "@web3modal/scaffold-react-native": "1.2.0",
+    "@web3modal/scaffold-utils-react-native": "1.2.0",
+    "@web3modal/ui-react-native": "1.2.0",
+    "@web3modal/wagmi-react-native": "1.2.0"
+  },
+  "changesets": [
+    "curvy-toys-press"
+  ]
+}

--- a/packages/ethers5/CHANGELOG.md
+++ b/packages/ethers5/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @web3modal/ethers5-react-native
 
+## 1.2.0-alpha.1
+
+### Patch Changes
+
+- added ethereum-provider as a dependency
+
 ## 1.2.0-alpha.0
 
 ### Minor Changes

--- a/packages/ethers5/package.json
+++ b/packages/ethers5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3modal/ethers5-react-native",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.0-alpha.1",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/index.d.ts",
   "module": "lib/module/index.js",


### PR DESCRIPTION
## What's Changed
* fix: added ethereum provider as a dependency by @ignaciosantise in https://github.com/WalletConnect/web3modal-react-native/pull/131