### PR TITLE
fix: removed wagmi Evaluate type from connectors

### DIFF
--- a/.changeset/good-cats-double.md
+++ b/.changeset/good-cats-double.md
@@ -1,0 +1,18 @@
+---
+'@web3modal/coinbase-ethers-react-native': patch
+'@web3modal/coinbase-wagmi-react-native': patch
+'@web3modal/scaffold-utils-react-native': patch
+'@web3modal/email-ethers-react-native': patch
+'@web3modal/email-wagmi-react-native': patch
+'@web3modal/scaffold-react-native': patch
+'@web3modal/ethers5-react-native': patch
+'@web3modal/common-react-native': patch
+'@web3modal/ethers-react-native': patch
+'@web3modal/email-react-native': patch
+'@web3modal/wagmi-react-native': patch
+'@web3modal/core-react-native': patch
+'@web3modal/siwe-react-native': patch
+'@web3modal/ui-react-native': patch
+---
+
+fix: removed wagmi Evaluate type from connectors

--- a/packages/coinbase-wagmi/src/index.ts
+++ b/packages/coinbase-wagmi/src/index.ts
@@ -6,15 +6,12 @@ import {
   ProviderRpcError,
   SwitchChainError
 } from 'viem';
-import type { Evaluate } from '@wagmi/core/internal';
 import { WalletMobileSDKEVMProvider, configure } from '@coinbase/wallet-mobile-sdk';
 import type { WalletMobileSDKProviderOptions } from '@coinbase/wallet-mobile-sdk/build/WalletMobileSDKEVMProvider';
 
-type CoinbaseConnectorParameters = Evaluate<
-  WalletMobileSDKProviderOptions & {
-    redirect: string;
-  }
->;
+type CoinbaseConnectorParameters = WalletMobileSDKProviderOptions & {
+  redirect: string;
+};
 
 type Provider = WalletMobileSDKEVMProvider;
 

--- a/packages/email-wagmi/src/index.ts
+++ b/packages/email-wagmi/src/index.ts
@@ -1,6 +1,6 @@
 import { createConnector, ChainNotConfiguredError } from 'wagmi';
 import { SwitchChainError, getAddress, type Address } from 'viem';
-import type { Evaluate } from '@wagmi/core/internal';
+
 import { W3mFrameProvider } from '@web3modal/email-react-native';
 
 export type Metadata = {
@@ -10,14 +10,14 @@ export type Metadata = {
   icons: string[];
 };
 
-type EmailProviderOptions = Evaluate<{
+type EmailProviderOptions = {
   /**
    * WalletConnect Cloud Project ID.
    * @link https://cloud.walletconnect.com/sign-in.
    */
   projectId: string;
   metadata: Metadata;
-}>;
+};
 
 type Provider = W3mFrameProvider;
 

--- a/packages/wagmi/src/connectors/WalletConnectConnector.ts
+++ b/packages/wagmi/src/connectors/WalletConnectConnector.ts
@@ -18,8 +18,6 @@ import {
   type Connector
 } from '@wagmi/core';
 
-import type { Evaluate, Omit } from '@wagmi/core/internal';
-
 import { EthereumProvider } from '@walletconnect/ethereum-provider';
 
 /**** Types ****/
@@ -29,61 +27,59 @@ type WalletConnectConnector = Connector & {
   onSessionDelete(data: { topic: string }): void;
 };
 
-export type WalletConnectParameters = Evaluate<
-  {
-    /**
-     * WalletConnect Cloud Project ID.
-     * @link https://cloud.walletconnect.com/sign-in.
-     */
-    projectId: EthereumProviderOptions['projectId'];
-    /**
-     * If a new chain is added to a previously existing configured connector `chains`, this flag
-     * will determine if that chain should be considered as stale. A stale chain is a chain that
-     * WalletConnect has yet to establish a relationship with (e.g. the user has not approved or
-     * rejected the chain).
-     *
-     * This flag mainly affects the behavior when a wallet does not support dynamic chain authorization
-     * with WalletConnect v2.
-     *
-     * If `true` (default), the new chain will be treated as a stale chain. If the user
-     * has yet to establish a relationship (approved/rejected) with this chain in their WalletConnect
-     * session, the connector will disconnect upon the dapp auto-connecting, and the user will have to
-     * reconnect to the dapp (revalidate the chain) in order to approve the newly added chain.
-     * This is the default behavior to avoid an unexpected error upon switching chains which may
-     * be a confusing user experience (e.g. the user will not know they have to reconnect
-     * unless the dapp handles these types of errors).
-     *
-     * If `false`, the new chain will be treated as a potentially valid chain. This means that if the user
-     * has yet to establish a relationship with the chain in their WalletConnect session, wagmi will successfully
-     * auto-connect the user. This comes with the trade-off that the connector will throw an error
-     * when attempting to switch to the unapproved chain if the wallet does not support dynamic session updates.
-     * This may be useful in cases where a dapp constantly
-     * modifies their configured chains, and they do not want to disconnect the user upon
-     * auto-connecting. If the user decides to switch to the unapproved chain, it is important that the
-     * dapp handles this error and prompts the user to reconnect to the dapp in order to approve
-     * the newly added chain.
-     *
-     * @default true
-     */
-    isNewChainsStale?: boolean;
-    /**
-     * Metadata for your app.
-     * @link https://docs.walletconnect.com/web3modal/react-native/about#implementation
-     */
-    metadata: EthereumProviderOptions['metadata'];
-  } & Omit<
-    EthereumProviderOptions,
-    | 'chains'
-    | 'events'
-    | 'optionalChains'
-    | 'optionalEvents'
-    | 'optionalMethods'
-    | 'methods'
-    | 'rpcMap'
-    | 'showQrModal'
-    | 'qrModalOptions'
-    | 'storageOptions'
-  >
+export type WalletConnectParameters = {
+  /**
+   * WalletConnect Cloud Project ID.
+   * @link https://cloud.walletconnect.com/sign-in.
+   */
+  projectId: EthereumProviderOptions['projectId'];
+  /**
+   * If a new chain is added to a previously existing configured connector `chains`, this flag
+   * will determine if that chain should be considered as stale. A stale chain is a chain that
+   * WalletConnect has yet to establish a relationship with (e.g. the user has not approved or
+   * rejected the chain).
+   *
+   * This flag mainly affects the behavior when a wallet does not support dynamic chain authorization
+   * with WalletConnect v2.
+   *
+   * If `true` (default), the new chain will be treated as a stale chain. If the user
+   * has yet to establish a relationship (approved/rejected) with this chain in their WalletConnect
+   * session, the connector will disconnect upon the dapp auto-connecting, and the user will have to
+   * reconnect to the dapp (revalidate the chain) in order to approve the newly added chain.
+   * This is the default behavior to avoid an unexpected error upon switching chains which may
+   * be a confusing user experience (e.g. the user will not know they have to reconnect
+   * unless the dapp handles these types of errors).
+   *
+   * If `false`, the new chain will be treated as a potentially valid chain. This means that if the user
+   * has yet to establish a relationship with the chain in their WalletConnect session, wagmi will successfully
+   * auto-connect the user. This comes with the trade-off that the connector will throw an error
+   * when attempting to switch to the unapproved chain if the wallet does not support dynamic session updates.
+   * This may be useful in cases where a dapp constantly
+   * modifies their configured chains, and they do not want to disconnect the user upon
+   * auto-connecting. If the user decides to switch to the unapproved chain, it is important that the
+   * dapp handles this error and prompts the user to reconnect to the dapp in order to approve
+   * the newly added chain.
+   *
+   * @default true
+   */
+  isNewChainsStale?: boolean;
+  /**
+   * Metadata for your app.
+   * @link https://docs.walletconnect.com/web3modal/react-native/about#implementation
+   */
+  metadata: EthereumProviderOptions['metadata'];
+} & Omit<
+  EthereumProviderOptions,
+  | 'chains'
+  | 'events'
+  | 'optionalChains'
+  | 'optionalEvents'
+  | 'optionalMethods'
+  | 'methods'
+  | 'rpcMap'
+  | 'showQrModal'
+  | 'qrModalOptions'
+  | 'storageOptions'
 >;
 
 type Provider = Awaited<ReturnType<(typeof EthereumProvider)['init']>>;


### PR DESCRIPTION
### Summary
The new version of Wagmi removed the type `Evaluate` from it's core causing a TS error.

According to their docs, there's no need to use it:
https://wagmi.sh/dev/creating-connectors#_3-create-the-connector-object