### PR TITLE
chore: cache action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,19 +8,9 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-
-    - name: Cache dependencies
-      id: yarn-cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          **/node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        cache: 'yarn'
 
     - name: Install dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: |
         yarn install --immutable
       shell: bash


### PR DESCRIPTION
### Summary
use `actions/setup-node@v4` cache instead of manual cache