### PR TITLE
fix: update recent wallets info after fetching

### DIFF
--- a/.changeset/forty-phones-begin.md
+++ b/.changeset/forty-phones-begin.md
@@ -1,0 +1,18 @@
+---
+'@web3modal/scaffold-react-native': patch
+'@web3modal/core-react-native': patch
+'@web3modal/coinbase-ethers-react-native': patch
+'@web3modal/coinbase-wagmi-react-native': patch
+'@web3modal/common-react-native': patch
+'@web3modal/email-react-native': patch
+'@web3modal/email-ethers-react-native': patch
+'@web3modal/email-wagmi-react-native': patch
+'@web3modal/ethers-react-native': patch
+'@web3modal/ethers5-react-native': patch
+'@web3modal/scaffold-utils-react-native': patch
+'@web3modal/siwe-react-native': patch
+'@web3modal/ui-react-native': patch
+'@web3modal/wagmi-react-native': patch
+---
+
+fix: update recent wallets info

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -39,7 +39,7 @@ export const StorageUtil = {
     }
   },
 
-  async setWeb3ModalRecent(wallet: WcWallet) {
+  async addRecentWallet(wallet: WcWallet) {
     try {
       const recentWallets = await StorageUtil.getRecentWallets();
       const recentIndex = recentWallets.findIndex(w => w.id === wallet.id);
@@ -48,7 +48,7 @@ export const StorageUtil = {
         recentWallets.splice(recentIndex, 1);
       }
 
-      recentWallets.unshift(wallet);
+      recentWallets.unshift({ ...wallet, name: 'pero asi d old' });
       if (recentWallets.length > 2) {
         recentWallets.pop();
       }
@@ -56,9 +56,17 @@ export const StorageUtil = {
 
       return recentWallets;
     } catch {
-      console.info('Unable to set Web3Modal recent');
+      console.info('Unable to set recent wallet');
 
       return undefined;
+    }
+  },
+
+  async setRecentWallets(wallets: WcWallet[]) {
+    try {
+      await AsyncStorage.setItem(W3M_RECENT, JSON.stringify(wallets));
+    } catch {
+      console.info('Unable to set recent wallets');
     }
   },
 
@@ -68,7 +76,7 @@ export const StorageUtil = {
 
       return recent ? JSON.parse(recent) : [];
     } catch {
-      console.info('Unable to get Web3Modal recent');
+      console.info('Unable to get recent wallets');
     }
 
     return [];

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -48,7 +48,7 @@ export const StorageUtil = {
         recentWallets.splice(recentIndex, 1);
       }
 
-      recentWallets.unshift({ ...wallet, name: 'pero asi d old' });
+      recentWallets.unshift(wallet);
       if (recentWallets.length > 2) {
         recentWallets.pop();
       }

--- a/packages/scaffold/src/utils/UiUtil.ts
+++ b/packages/scaffold/src/utils/UiUtil.ts
@@ -20,7 +20,7 @@ export const UiUtil = {
     StorageUtil.setWalletConnectDeepLink(wcLinking);
 
     if (pressedWallet) {
-      const recentWallets = await StorageUtil.setWeb3ModalRecent(pressedWallet);
+      const recentWallets = await StorageUtil.addRecentWallet(pressedWallet);
       if (recentWallets) {
         ConnectionController.setRecentWallets(recentWallets);
       }

--- a/packages/scaffold/src/views/w3m-connect-view/components/all-wallet-list.tsx
+++ b/packages/scaffold/src/views/w3m-connect-view/components/all-wallet-list.tsx
@@ -14,7 +14,6 @@ import { filterOutRecentWallets } from '../utils';
 interface Props {
   itemStyle: StyleProp<ViewStyle>;
   onWalletPress: (wallet: WcWallet) => void;
-
   isWalletConnectEnabled: boolean;
 }
 

--- a/packages/scaffold/src/views/w3m-connecting-external-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-connecting-external-view/index.tsx
@@ -38,7 +38,7 @@ export function ConnectingExternalView() {
   const storeConnectedWallet = useCallback(
     async (wallet?: WcWallet) => {
       if (wallet) {
-        const recentWallets = await StorageUtil.setWeb3ModalRecent(wallet);
+        const recentWallets = await StorageUtil.addRecentWallet(wallet);
         if (recentWallets) {
           ConnectionController.setRecentWallets(recentWallets);
         }


### PR DESCRIPTION
### Summary
* Update recent wallet info saved in local storage when fetching new data from API
This will help keeping the local storage data up to date with the wallets cloud settings

### Video
The dapp has old data saved in recent wallets. But it's updated after the sdk fetches new data from API

https://github.com/user-attachments/assets/8a16dedf-ad57-4f47-8620-be211f92a7e2

