### PR TITLE
fix: reset pairing if it fails

### DIFF
--- a/.changeset/wild-masks-pay.md
+++ b/.changeset/wild-masks-pay.md
@@ -1,0 +1,18 @@
+---
+'@web3modal/scaffold-react-native': patch
+'@web3modal/ethers5-react-native': patch
+'@web3modal/ethers-react-native': patch
+'@web3modal/core-react-native': patch
+'@web3modal/coinbase-ethers-react-native': patch
+'@web3modal/coinbase-wagmi-react-native': patch
+'@web3modal/common-react-native': patch
+'@web3modal/email-react-native': patch
+'@web3modal/email-ethers-react-native': patch
+'@web3modal/email-wagmi-react-native': patch
+'@web3modal/scaffold-utils-react-native': patch
+'@web3modal/siwe-react-native': patch
+'@web3modal/ui-react-native': patch
+'@web3modal/wagmi-react-native': patch
+---
+
+fix: reset pairing if it fails

--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -85,19 +85,6 @@ export const ConnectionController = {
     return this._getClient().signMessage(message);
   },
 
-  resetWcConnection() {
-    state.wcUri = undefined;
-    state.wcPairingExpiry = undefined;
-    state.wcPromise = undefined;
-    state.wcLinking = undefined;
-    state.pressedWallet = undefined;
-    state.connectedWalletImageUrl = undefined;
-    ConnectorController.setConnectedConnector(undefined);
-    StorageUtil.removeWalletConnectDeepLink();
-    StorageUtil.removeConnectedWalletImageUrl();
-    StorageUtil.removeConnectedConnector();
-  },
-
   setWcLinking(wcLinking: ConnectionControllerState['wcLinking']) {
     state.wcLinking = wcLinking;
   },
@@ -130,6 +117,23 @@ export const ConnectionController = {
     } else {
       StorageUtil.removeConnectedWalletImageUrl();
     }
+  },
+
+  clearUri() {
+    state.wcUri = undefined;
+    state.wcPairingExpiry = undefined;
+    state.wcPromise = undefined;
+    state.wcLinking = undefined;
+  },
+
+  resetWcConnection() {
+    this.clearUri();
+    state.pressedWallet = undefined;
+    state.connectedWalletImageUrl = undefined;
+    ConnectorController.setConnectedConnector(undefined);
+    StorageUtil.removeWalletConnectDeepLink();
+    StorageUtil.removeConnectedWalletImageUrl();
+    StorageUtil.removeConnectedConnector();
   },
 
   async disconnect() {

--- a/packages/scaffold/src/views/w3m-connecting-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-connecting-view/index.tsx
@@ -61,6 +61,7 @@ export function ConnectingView() {
       }
     } catch (error) {
       ConnectionController.setWcError(true);
+      ConnectionController.clearUri();
       SnackController.showError('Declined');
       if (isQr && CoreHelperUtil.isAllowedRetry(lastRetry)) {
         setLastRetry(Date.now());
@@ -130,13 +131,16 @@ export function ConnectingView() {
 
   useEffect(() => {
     initializeConnection();
+    let _interval: NodeJS.Timeout;
 
     // Check if the pairing expired every 10 seconds. If expired, it will create a new uri.
-    const _interval = setInterval(initializeConnection, ConstantsUtil.TEN_SEC_MS);
+    if (isQr) {
+      _interval = setInterval(initializeConnection, ConstantsUtil.TEN_SEC_MS);
+    }
 
     return () => clearInterval(_interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isQr]);
 
   return (
     <>


### PR DESCRIPTION
### Summary
* If the user declines the connection request, clear the uri + pairing expiration so it generates a new one
* subscribe to expiry check only if the user is in QR view

### Screenshot

https://github.com/user-attachments/assets/b71f4216-434a-49bc-9088-ec03fa9e9a42

### Linear
https://linear.app/walletconnect/issue/WK-328/rn-dapp-swift-wallet-after-declining-once-from-the-wallet-approval-is