### PR TITLE
fix: disable layout animations on ios new arch projects

### DIFF
--- a/.changeset/shaggy-plants-fly.md
+++ b/.changeset/shaggy-plants-fly.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: disable layout animations on ios new arch projects

--- a/packages/scaffold/src/utils/UiUtil.ts
+++ b/packages/scaffold/src/utils/UiUtil.ts
@@ -4,13 +4,18 @@ import {
   StorageUtil,
   type WcWallet
 } from '@reown/appkit-core-react-native';
-import { LayoutAnimation } from 'react-native';
+import { LayoutAnimation, Platform } from 'react-native';
 
 export const UiUtil = {
   TOTAL_VISIBLE_WALLETS: 4,
 
   createViewTransition: () => {
-    LayoutAnimation.configureNext(LayoutAnimation.create(200, 'easeInEaseOut', 'opacity'));
+    const IS_IOS_NEW_ARCH = Platform.OS === 'ios' && (global as any)?.nativeFabricUIManager != null;
+
+    // Disable layout animation for new arch on iOS -> https://github.com/facebook/react-native/issues/47617
+    if (!IS_IOS_NEW_ARCH) {
+      LayoutAnimation.configureNext(LayoutAnimation.create(200, 'easeInEaseOut', 'opacity'));
+    }
   },
 
   storeConnectedWallet: async (


### PR DESCRIPTION
### Summary
LayoutAnimations are not working anymore on iOS projects with new arch enabled -> https://github.com/facebook/react-native/issues/47617

### Related
https://github.com/reown-com/appkit-react-native/issues/374