### PR TITLE
fix: solved re-render issues in useAppKit hook

### DIFF
--- a/packages/appkit/src/AppKitContext.tsx
+++ b/packages/appkit/src/AppKitContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, type ReactNode } from 'react';
+import React, { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { AppKit } from './AppKit';
 
 interface AppKitContextType {
@@ -26,14 +26,22 @@ export const useInternalAppKit = () => {
     throw new Error('AppKit instance is not yet available in context.');
   }
 
-  return {
-    connect: context.appKit.connect.bind(context.appKit),
-    disconnect: context.appKit.disconnect.bind(context.appKit),
-    open: context.appKit.open.bind(context.appKit),
-    close: context.appKit.close.bind(context.appKit),
-    back: context.appKit.back.bind(context.appKit),
-    switchNetwork: context.appKit.switchNetwork.bind(context.appKit),
-    getProvider: context.appKit.getProvider.bind(context.appKit),
-    switchAccountType: context.appKit.switchAccountType.bind(context.appKit)
-  };
+  const stableFunctions = useMemo(() => {
+    if (!context.appKit) {
+      throw new Error('AppKit instance is not available');
+    }
+
+    return {
+      connect: context.appKit.connect.bind(context.appKit),
+      disconnect: context.appKit.disconnect.bind(context.appKit),
+      open: context.appKit.open.bind(context.appKit),
+      close: context.appKit.close.bind(context.appKit),
+      back: context.appKit.back.bind(context.appKit),
+      switchNetwork: context.appKit.switchNetwork.bind(context.appKit),
+      getProvider: context.appKit.getProvider.bind(context.appKit),
+      switchAccountType: context.appKit.switchAccountType.bind(context.appKit)
+    };
+  }, [context.appKit]);
+
+  return stableFunctions;
 };

--- a/packages/appkit/src/hooks/useAppKit.ts
+++ b/packages/appkit/src/hooks/useAppKit.ts
@@ -1,6 +1,4 @@
-import { useContext } from 'react';
-import { useSnapshot } from 'valtio';
-import { ModalController } from '@reown/appkit-core-react-native';
+import { useContext, useMemo } from 'react';
 
 import type { AppKit } from '../AppKit';
 import { AppKitContext } from '../AppKitContext';
@@ -10,26 +8,33 @@ interface UseAppKitReturn {
   close: AppKit['close'];
   disconnect: (namespace?: string) => void;
   switchNetwork: AppKit['switchNetwork'];
-  isOpen: boolean;
 }
 
 export const useAppKit = (): UseAppKitReturn => {
   const context = useContext(AppKitContext);
-  const { open } = useSnapshot(ModalController.state);
 
   if (context === undefined) {
     throw new Error('useAppKit must be used within an AppKitProvider');
   }
+
   if (!context.appKit) {
     // This might happen if the provider is rendered before AppKit is initialized
     throw new Error('AppKit instance is not yet available in context.');
   }
 
-  return {
-    open: context.appKit.open.bind(context.appKit),
-    close: context.appKit.close.bind(context.appKit),
-    disconnect: (namespace?: string) => context.appKit?.disconnect.bind(context.appKit)(namespace),
-    switchNetwork: context.appKit.switchNetwork.bind(context.appKit),
-    isOpen: open
-  };
+  const stableFunctions = useMemo(() => {
+    if (!context.appKit) {
+      throw new Error('AppKit instance is not available');
+    }
+
+    return {
+      open: context.appKit.open.bind(context.appKit),
+      close: context.appKit.close.bind(context.appKit),
+      disconnect: (namespace?: string) =>
+        context.appKit!.disconnect.bind(context.appKit!)(namespace),
+      switchNetwork: context.appKit.switchNetwork.bind(context.appKit)
+    };
+  }, [context.appKit]);
+
+  return stableFunctions;
 };


### PR DESCRIPTION
This pull request refactors the `useAppKit` and `useInternalAppKit` hooks to improve the stability and performance of the functions they return. The main change is the use of `useMemo` to memoize the returned functions, ensuring they remain stable across renders unless the `AppKit` instance changes. Additionally, some unused code and dependencies have been removed for simplification.

**Hook improvements and code simplification:**

* Refactored both `useAppKit` and `useInternalAppKit` hooks to use `useMemo`, ensuring that the returned functions are stable and only recreated when the `AppKit` instance changes. This helps prevent unnecessary re-renders and improves performance. (`packages/appkit/src/AppKitContext.tsx`, `packages/appkit/src/hooks/useAppKit.ts`) [[1]](diffhunk://#diff-4578755733857a169a32874a0602896606892810d565125fbf2cc3741f72186eL1-R1) [[2]](diffhunk://#diff-4578755733857a169a32874a0602896606892810d565125fbf2cc3741f72186eR29-R33) [[3]](diffhunk://#diff-4578755733857a169a32874a0602896606892810d565125fbf2cc3741f72186eR44-R46) [[4]](diffhunk://#diff-40c52ee6b53bad082f6b44903da5d6c3225745d58683b506af135558b9139270L1-R1) [[5]](diffhunk://#diff-40c52ee6b53bad082f6b44903da5d6c3225745d58683b506af135558b9139270L13-R39)
* Removed the `isOpen` property from the `useAppKit` hook, simplifying the code and its interface. (`packages/appkit/src/hooks/useAppKit.ts`) [[1]](diffhunk://#diff-40c52ee6b53bad082f6b44903da5d6c3225745d58683b506af135558b9139270L1-R1) [[2]](diffhunk://#diff-40c52ee6b53bad082f6b44903da5d6c3225745d58683b506af135558b9139270L13-R39)