### PR TITLE
chore: added useAppKitState hook + hooks improvements

### DIFF
--- a/apps/native/src/views/ActionsView.tsx
+++ b/apps/native/src/views/ActionsView.tsx
@@ -9,7 +9,7 @@ import { WagmiActionsView } from './WagmiActionsView';
 
 export function ActionsView() {
   const isConnected = true;
-  const { namespace} = useAccount();
+  const { namespace } = useAccount();
 
   return isConnected ? (
     <FlexView style={styles.container}>

--- a/apps/native/src/views/WalletInfoView.tsx
+++ b/apps/native/src/views/WalletInfoView.tsx
@@ -11,16 +11,16 @@ export function WalletInfoView({ style }: Props) {
   const { address, chain } = useAccount();
 
   return walletInfo ? (
-    <FlexView style={style} alignItems="center">
+    <FlexView style={style} padding="m" alignItems="center">
       <Text variant="small-600" style={styles.label}>
         Connected to
       </Text>
       <FlexView flexDirection="row" alignItems="center">
         {walletInfo?.icons?.[0] ? <Image style={styles.logo} source={{ uri: walletInfo?.icons?.[0] }} /> : null}
         {walletInfo?.name ? <Text variant="small-400">{walletInfo?.name}</Text> : null}
-        {chain?.name ? <Text variant="small-400">{chain?.name}</Text> : null}
-        {address ? <Text variant="small-400">{address}</Text> : null}
       </FlexView>
+        {address ? <Text ellipsizeMode="middle" numberOfLines={1} variant="small-400">Address: {address}</Text> : null}
+        {chain?.name ? <Text variant="small-400">Chain: {chain?.name}</Text> : null}
     </FlexView>
   ) : null;
 }

--- a/apps/native/src/views/WalletInfoView.tsx
+++ b/apps/native/src/views/WalletInfoView.tsx
@@ -1,5 +1,5 @@
 import { Image, StyleSheet, StyleProp, ViewStyle } from 'react-native';
-import { useWalletInfo } from '@reown/appkit-react-native';
+import { useAccount, useWalletInfo } from '@reown/appkit-react-native';
 import { FlexView, Text } from '@reown/appkit-ui-react-native';
 
 interface Props {
@@ -8,6 +8,7 @@ interface Props {
 
 export function WalletInfoView({ style }: Props) {
   const { walletInfo } = useWalletInfo();
+  const { address, chain } = useAccount();
 
   return walletInfo ? (
     <FlexView style={style} alignItems="center">
@@ -17,6 +18,8 @@ export function WalletInfoView({ style }: Props) {
       <FlexView flexDirection="row" alignItems="center">
         {walletInfo?.icons?.[0] ? <Image style={styles.logo} source={{ uri: walletInfo?.icons?.[0] }} /> : null}
         {walletInfo?.name ? <Text variant="small-400">{walletInfo?.name}</Text> : null}
+        {chain?.name ? <Text variant="small-400">{chain?.name}</Text> : null}
+        {address ? <Text variant="small-400">{address}</Text> : null}
       </FlexView>
     </FlexView>
   ) : null;

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -1,3 +1,5 @@
+/* eslint-disable valtio/state-snapshot-rule */
+import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController, CoreHelperUtil } from '@reown/appkit-core-react-native';
 import { useAppKit } from './useAppKit';
@@ -12,10 +14,13 @@ export function useAccount() {
     networks
   } = useSnapshot(ConnectionsController.state);
 
-  const activeChain = connection?.caipNetwork
-    ? // eslint-disable-next-line valtio/state-snapshot-rule
-      networks.find(network => network.caipNetworkId === connection?.caipNetwork)
-    : undefined;
+  const activeChain = useMemo(
+    () =>
+      connection?.caipNetwork
+        ? networks.find(network => network.caipNetworkId === connection?.caipNetwork)
+        : undefined,
+    [connection?.caipNetwork, networks]
+  );
 
   return {
     address: CoreHelperUtil.getPlainAddress(address),

--- a/packages/appkit/src/hooks/useAppKitState.ts
+++ b/packages/appkit/src/hooks/useAppKitState.ts
@@ -1,0 +1,21 @@
+import { useSnapshot } from 'valtio';
+import { ConnectionsController, ModalController } from '@reown/appkit-core-react-native';
+import { useAppKit } from './useAppKit';
+
+export function useAppKitState() {
+  useAppKit(); // Use the hook for checks
+  const { activeAddress: address, connection, networks } = useSnapshot(ConnectionsController.state);
+  const { open, loading } = useSnapshot(ModalController.state);
+
+  const activeChain = connection?.caipNetwork
+    ? // eslint-disable-next-line valtio/state-snapshot-rule
+      networks.find(network => network.caipNetworkId === connection?.caipNetwork)
+    : undefined;
+
+  return {
+    isOpen: open,
+    isLoading: loading,
+    isConnected: !!address,
+    chain: activeChain
+  };
+}

--- a/packages/appkit/src/hooks/useAppKitState.ts
+++ b/packages/appkit/src/hooks/useAppKitState.ts
@@ -1,3 +1,5 @@
+/* eslint-disable valtio/state-snapshot-rule */
+import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController, ModalController } from '@reown/appkit-core-react-native';
 import { useAppKit } from './useAppKit';
@@ -7,10 +9,13 @@ export function useAppKitState() {
   const { activeAddress: address, connection, networks } = useSnapshot(ConnectionsController.state);
   const { open, loading } = useSnapshot(ModalController.state);
 
-  const activeChain = connection?.caipNetwork
-    ? // eslint-disable-next-line valtio/state-snapshot-rule
-      networks.find(network => network.caipNetworkId === connection?.caipNetwork)
-    : undefined;
+  const activeChain = useMemo(
+    () =>
+      connection?.caipNetwork
+        ? networks.find(network => network.caipNetworkId === connection?.caipNetwork)
+        : undefined,
+    [connection?.caipNetwork, networks]
+  );
 
   return {
     isOpen: open,

--- a/packages/appkit/src/hooks/useProvider.ts
+++ b/packages/appkit/src/hooks/useProvider.ts
@@ -1,3 +1,5 @@
+/* eslint-disable valtio/state-snapshot-rule */
+import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController } from '@reown/appkit-core-react-native';
 import type { Provider, ChainNamespace } from '@reown/appkit-common-react-native';
@@ -37,10 +39,14 @@ interface ProviderResult {
 export function useProvider(): ProviderResult {
   const { connection } = useSnapshot(ConnectionsController.state);
 
-  if (!connection) return { provider: undefined, providerType: undefined };
+  const returnValue = useMemo(() => {
+    if (!connection) return { provider: undefined, providerType: undefined };
 
-  return {
-    provider: connection.adapter.getProvider(),
-    providerType: connection.adapter.getSupportedNamespace()
-  };
+    return {
+      provider: connection.adapter.getProvider(),
+      providerType: connection.adapter.getSupportedNamespace()
+    };
+  }, [connection]);
+
+  return returnValue;
 }

--- a/packages/appkit/src/hooks/useWalletInfo.ts
+++ b/packages/appkit/src/hooks/useWalletInfo.ts
@@ -1,10 +1,13 @@
+import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController } from '@reown/appkit-core-react-native';
 import { useAppKit } from './useAppKit';
 
 export function useWalletInfo() {
   useAppKit(); // Use the hook for checks
-  const { walletInfo } = useSnapshot(ConnectionsController.state);
+  const { walletInfo: walletInfoSnapshot } = useSnapshot(ConnectionsController.state);
 
-  return { walletInfo };
+  const walletInfo = useMemo(() => ({ walletInfo: walletInfoSnapshot }), [walletInfoSnapshot]);
+
+  return walletInfo;
 }

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -25,6 +25,7 @@ export { useProvider } from './hooks/useProvider';
 export { useAccount } from './hooks/useAccount';
 export { useWalletInfo } from './hooks/useWalletInfo';
 export { useAppKitEvents, useAppKitEventSubscription } from './hooks/useAppKitEvents';
+export { useAppKitState } from './hooks/useAppKitState';
 
 /********** Networks **********/
 export { solana, solanaDevnet, solanaTestnet } from '@reown/appkit-common-react-native';


### PR DESCRIPTION
This pull request improves the performance and reliability of several React hooks in the appkit package by memoizing computed values and standardizing state access. It also introduces a new `useAppKitState` hook for consolidated app state, and enhances the `WalletInfoView` to display more account information.

**React hook improvements:**

* Memoized the computation of `activeChain` in `useAccount` and `useAppKitState` to prevent unnecessary recalculations and re-renders. [[1]](diffhunk://#diff-5e28fa50392758d6ea9f962289511e92caf24dcbf4aa27590cfd202224da1838L15-R23) [[2]](diffhunk://#diff-2a793d4b4210bd5bc75071247f0eb5cfc14e835abb59394c3caa6f53075189f0R1-R26)
* Memoized the provider object in `useProvider` for more efficient updates.
* Memoized the return value in `useWalletInfo` for consistency and performance.

**New features and exports:**

* Added a new `useAppKitState` hook that provides consolidated modal, connection, and chain state, and exported it from the package. [[1]](diffhunk://#diff-2a793d4b4210bd5bc75071247f0eb5cfc14e835abb59394c3caa6f53075189f0R1-R26) [[2]](diffhunk://#diff-5b4f777bab03e60e294fa198886884389a82d43331fe5893c462771ef96dd291R28)