### PR TITLE
fix: correct spelling error in auth-wagmi package

### DIFF
--- a/packages/auth-wagmi/src/index.ts
+++ b/packages/auth-wagmi/src/index.ts
@@ -64,7 +64,7 @@ export function authConnector(parameters: AuthConnectorOptions) {
         chainId: frameChainId as number,
         chain: {
           id: frameChainId as number,
-          unsuported: false
+          unsupported: false
         }
       };
     },


### PR DESCRIPTION
 Corrected `unsuported` → `unsupported` 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a typo in the returned `chain` object (`unsuported` → `unsupported`) in `packages/auth-wagmi/src/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0439dfe48351e70294b84664fe485ca17bd2ac15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->