### PR TITLE
chore: updated claude review action + using default model

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -28,10 +28,9 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Auto Review
-        uses: WalletConnect/actions/claude/auto-review@1483e05460107d74c575e31af948ce20f9df6387
+        uses: WalletConnect/actions/claude/auto-review@d6395999d484da4e542b83d345532c284ced539c
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
           timeout_minutes: "60"
           project_context: |
             This is the AppKit React Native SDK, a comprehensive wallet connection and blockchain interaction library for React Native applications.


### PR DESCRIPTION
### Summary
* Updated claude-code review action
* Use default model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions Claude auto-review workflow to a new action revision and removes the explicit model to rely on the default.
> 
> - **CI / GitHub Actions**:
>   - **Claude Auto Review workflow**: Update action ref to `WalletConnect/actions/claude/auto-review@d6395999...`.
>   - **Config**: Remove explicit `model` input to use the action's default model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83b06d0ab08a57024e73be94b9f64b65a4699d69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->