### PR TITLE
fix: use singleton to persist appkit instance

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -47,7 +47,7 @@ import { type AppKitConfig } from './types';
 import { SIWXUtil } from './utils/SIWXUtil';
 
 declare global {
-  var __APPKIT_INSTANCE__: AppKit | undefined;
+  var __REOWN_APPKIT_INSTANCE__: AppKit | undefined;
 }
 
 export class AppKit {
@@ -835,15 +835,19 @@ export class AppKit {
   };
 }
 
-export function createAppKit(config: AppKitConfig): AppKit {
-  if (global.__APPKIT_INSTANCE__) {
-    LogController.sendDebug('AppKit: Reusing existing instance', 'AppKit.ts', 'createAppKit');
-    return global.__APPKIT_INSTANCE__;
+export function createAppKit(config: AppKitConfig) {
+  try {
+    if (globalThis.__REOWN_APPKIT_INSTANCE__) {
+      LogController.sendDebug('AppKit: Reusing existing instance', 'AppKit.ts', 'createAppKit');
+      return globalThis.__REOWN_APPKIT_INSTANCE__;
+    }
+
+    LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
+    const instance = new AppKit(config);
+    globalThis.__REOWN_APPKIT_INSTANCE__ = instance;
+    return instance;
+  } catch (error) {
+    LogController.sendError(error, 'AppKit.ts', 'createAppKit');
+    return undefined;
   }
-
-  LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
-  const instance = new AppKit(config);
-  global.__APPKIT_INSTANCE__ = instance;
-
-  return instance;
 }

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -848,6 +848,6 @@ export function createAppKit(config: AppKitConfig) {
     return instance;
   } catch (error) {
     LogController.sendError(error, 'AppKit.ts', 'createAppKit');
-    return undefined;
+    throw error;
   }
 }

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -46,8 +46,11 @@ import { RouterUtil } from './utils/RouterUtil';
 import { type AppKitConfig } from './types';
 import { SIWXUtil } from './utils/SIWXUtil';
 
-declare global {
-  var __REOWN_APPKIT_INSTANCE__: AppKit | undefined;
+const APPKIT_INSTANCE_KEY = Symbol.for('__REOWN_APPKIT_INSTANCE__');
+
+// Type helper to access the symbol-keyed property on globalThis
+interface GlobalWithAppKit {
+  [key: symbol]: AppKit | undefined;
 }
 
 export class AppKit {
@@ -835,21 +838,29 @@ export class AppKit {
   };
 }
 
-export function createAppKit(config: AppKitConfig) {
+/**
+ * Creates or returns the existing AppKit singleton instance.
+ *
+ * @warning This function implements a singleton pattern. If an instance already exists,
+ * it will be returned and the provided config parameter will be IGNORED. If you need to
+ * change configuration, you must reload your application or clear the singleton manually.
+ *
+ * @param config - AppKit configuration options
+ * @returns The AppKit singleton instance
+ * @throws Error if configuration validation fails
+ */
+export function createAppKit(config: AppKitConfig): AppKit {
   try {
-    if (globalThis.__REOWN_APPKIT_INSTANCE__) {
-      LogController.sendDebug('AppKit: Reusing existing instance', 'AppKit.ts', 'createAppKit');
+    const globalWithAppKit = globalThis as GlobalWithAppKit;
 
-      return globalThis.__REOWN_APPKIT_INSTANCE__;
+    if (!globalWithAppKit[APPKIT_INSTANCE_KEY]) {
+      globalWithAppKit[APPKIT_INSTANCE_KEY] = new AppKit(config);
+      LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
     }
 
-    LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
-    const instance = new AppKit(config);
-    globalThis.__REOWN_APPKIT_INSTANCE__ = instance;
-
-    return instance;
+    return globalWithAppKit[APPKIT_INSTANCE_KEY]!;
   } catch (error) {
-    LogController.sendError(error, 'AppKit.ts', 'createAppKit');
+    console.error(error);
     throw error;
   }
 }

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -854,13 +854,22 @@ export function createAppKit(config: AppKitConfig): AppKit {
     const globalWithAppKit = globalThis as GlobalWithAppKit;
 
     if (!globalWithAppKit[APPKIT_INSTANCE_KEY]) {
+      if (config.debug && __DEV__) {
+        // using console.log to avoid possible issues with LogController not being initialized
+        console.log('AppKit: Creating new instance - AppKit.ts:createAppKit');
+      }
       globalWithAppKit[APPKIT_INSTANCE_KEY] = new AppKit(config);
-      LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
+    } else if (config.debug && __DEV__) {
+      console.log('AppKit: Reusing existing instance - AppKit.ts:createAppKit');
     }
 
     return globalWithAppKit[APPKIT_INSTANCE_KEY]!;
   } catch (error) {
-    LogController.sendError(error, 'AppKit.ts', 'createAppKit');
+    if (__DEV__) {
+      // using console.error to avoid possible issues with LogController not being initialized
+      console.error('AppKit: Failed to create instance - AppKit.ts:createAppKit', error);
+    }
+
     throw error;
   }
 }

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -860,7 +860,7 @@ export function createAppKit(config: AppKitConfig): AppKit {
 
     return globalWithAppKit[APPKIT_INSTANCE_KEY]!;
   } catch (error) {
-    console.error(error);
+    LogController.sendError(error, 'AppKit.ts', 'createAppKit');
     throw error;
   }
 }

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -839,12 +839,14 @@ export function createAppKit(config: AppKitConfig) {
   try {
     if (globalThis.__REOWN_APPKIT_INSTANCE__) {
       LogController.sendDebug('AppKit: Reusing existing instance', 'AppKit.ts', 'createAppKit');
+
       return globalThis.__REOWN_APPKIT_INSTANCE__;
     }
 
     LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
     const instance = new AppKit(config);
     globalThis.__REOWN_APPKIT_INSTANCE__ = instance;
+
     return instance;
   } catch (error) {
     LogController.sendError(error, 'AppKit.ts', 'createAppKit');

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -856,10 +856,12 @@ export function createAppKit(config: AppKitConfig): AppKit {
     if (!globalWithAppKit[APPKIT_INSTANCE_KEY]) {
       if (config.debug && __DEV__) {
         // using console.log to avoid possible issues with LogController not being initialized
+        //eslint-disable-next-line no-console
         console.log('AppKit: Creating new instance - AppKit.ts:createAppKit');
       }
       globalWithAppKit[APPKIT_INSTANCE_KEY] = new AppKit(config);
     } else if (config.debug && __DEV__) {
+      //eslint-disable-next-line no-console
       console.log('AppKit: Reusing existing instance - AppKit.ts:createAppKit');
     }
 
@@ -867,6 +869,7 @@ export function createAppKit(config: AppKitConfig): AppKit {
   } catch (error) {
     if (__DEV__) {
       // using console.error to avoid possible issues with LogController not being initialized
+      //eslint-disable-next-line no-console
       console.error('AppKit: Failed to create instance - AppKit.ts:createAppKit', error);
     }
 

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -46,6 +46,10 @@ import { RouterUtil } from './utils/RouterUtil';
 import { type AppKitConfig } from './types';
 import { SIWXUtil } from './utils/SIWXUtil';
 
+declare global {
+  var __APPKIT_INSTANCE__: AppKit | undefined;
+}
+
 export class AppKit {
   private projectId: string;
   private adapters: BlockchainAdapter[];
@@ -832,5 +836,14 @@ export class AppKit {
 }
 
 export function createAppKit(config: AppKitConfig): AppKit {
-  return new AppKit(config);
+  if (global.__APPKIT_INSTANCE__) {
+    LogController.sendDebug('AppKit: Reusing existing instance', 'AppKit.ts', 'createAppKit');
+    return global.__APPKIT_INSTANCE__;
+  }
+
+  LogController.sendDebug('AppKit: Creating new instance', 'AppKit.ts', 'createAppKit');
+  const instance = new AppKit(config);
+  global.__APPKIT_INSTANCE__ = instance;
+
+  return instance;
 }


### PR DESCRIPTION
This pull request introduces a singleton pattern for the `AppKit` class to ensure that only one instance exists globally, and adds logging for instance creation and error handling.

Instance management and singleton implementation:

* Declared a global variable `__REOWN_APPKIT_INSTANCE__` to store the singleton instance of `AppKit`, preventing multiple instances from being created.
* Updated the `createAppKit` function to check for an existing instance in `globalThis.__REOWN_APPKIT_INSTANCE__`, reuse it if present, or create and store a new instance if not.

Logging and error handling:

* Added debug logs for both reusing an existing instance and creating a new one, and implemented error logging with graceful fallback to `undefined` if instantiation fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a global `AppKit` singleton using a symbol on `globalThis`, updating `createAppKit` to reuse/create the instance with dev logs and error handling.
> 
> - **Core**:
>   - **Singleton**: Introduces `APPKIT_INSTANCE_KEY` (symbol) and `GlobalWithAppKit` to store a single `AppKit` instance on `globalThis`.
>   - **Factory Update**: `createAppKit(config)` now returns the existing instance if present or creates one, ignoring new config when reusing.
>   - **Logging/Error Handling**: Adds dev-only console logs for create/reuse paths and error logging on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6cc8a1b9e099f453fde82a36d1da1c920a74404. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->