### PR TITLE
chore: fix claude action

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -28,9 +28,10 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Auto Review
-        uses: WalletConnect/actions/claude/auto-review@d6395999d484da4e542b83d345532c284ced539c
+        uses: WalletConnect/actions/claude/auto-review@1483e05460107d74c575e31af948ce20f9df6387
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-5-20250929
           timeout_minutes: "60"
           project_context: |
             This is the AppKit React Native SDK, a comprehensive wallet connection and blockchain interaction library for React Native applications.


### PR DESCRIPTION
Fixed claude action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Claude auto-review GitHub Action ref and specifies the `claude-sonnet-4-5-20250929` model.
> 
> - **CI/CD**:
>   - **GitHub Actions** (`.github/workflows/claude-auto-review.yml`):
>     - Bump `WalletConnect/actions/claude/auto-review` to commit `1483e05460107d74c575e31af948ce20f9df6387`.
>     - Configure `model` to `claude-sonnet-4-5-20250929`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 758c14c4dce47e0b9e99e3dc92a368646954700a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->