### PR TITLE
fix: unsupported network popup + wagmi duplicated event subscription

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -634,7 +634,7 @@ export class AppKit {
       const namespace = adapter.getSupportedNamespace();
       const chain = `${namespace}:${chainId}` as CaipNetworkId;
 
-      const activeNetwork = ConnectionsController.getActiveNetwork(namespace);
+      const activeNetwork = ConnectionsController.getActiveNetworkId(namespace);
       if (activeNetwork === chain) {
         // No need to update the active network
         return;

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -633,6 +633,13 @@ export class AppKit {
 
       const namespace = adapter.getSupportedNamespace();
       const chain = `${namespace}:${chainId}` as CaipNetworkId;
+
+      const activeNetwork = ConnectionsController.getActiveNetwork(namespace);
+      if (activeNetwork === chain) {
+        // No need to update the active network
+        return;
+      }
+
       ConnectionsController.setActiveNetwork(namespace, chain);
 
       const connection = ConnectionsController.state.connections.get(namespace);
@@ -654,7 +661,13 @@ export class AppKit {
         TransactionsController.fetchTransactions(address, true);
       }
 
-      SIWXUtil.initializeIfEnabled({ onDisconnect: this.disconnect, caipAddress: address });
+      const closeModal = RouterController.state.view === 'UnsupportedChain';
+
+      SIWXUtil.initializeIfEnabled({
+        onDisconnect: this.disconnect,
+        caipAddress: address,
+        closeModal
+      });
     });
 
     adapter.on('disconnect', () => {

--- a/packages/appkit/src/utils/SIWXUtil.ts
+++ b/packages/appkit/src/utils/SIWXUtil.ts
@@ -293,8 +293,6 @@ export const SIWXUtil = {
       universalLink
     );
 
-    SnackController.showLoading('Authenticating...', true);
-
     if (result?.auths?.length) {
       const sessions = result.auths.map<SIWXSession>(cacao => {
         const message = universalProvider.client.formatAuthMessage({
@@ -320,6 +318,7 @@ export const SIWXUtil = {
       });
 
       try {
+        SnackController.showLoading('Authenticating...', true);
         await siwx.setSessions(sessions);
 
         EventsController.sendEvent({

--- a/packages/appkit/src/utils/SIWXUtil.ts
+++ b/packages/appkit/src/utils/SIWXUtil.ts
@@ -16,7 +16,6 @@ import {
   EventsController,
   LogController
 } from '@reown/appkit-core-react-native';
-import { Alert } from 'react-native';
 
 /**
  * SIWXUtil holds the methods to interact with the SIWX plugin and must be called internally on AppKit.
@@ -153,10 +152,7 @@ export const SIWXUtil = {
           view: 'SIWXSignMessage'
         });
       }
-
-      // @ts-ignore
-      Alert.alert('Error signing message', error?.message ?? error);
-
+      SnackController.hide();
       SnackController.showError('Error signing message');
       EventsController.sendEvent({
         type: 'track',

--- a/packages/common/src/adapters/BlockchainAdapter.ts
+++ b/packages/common/src/adapters/BlockchainAdapter.ts
@@ -86,6 +86,7 @@ export abstract class BlockchainAdapter extends EventEmitter {
     const updatedAccounts =
       _accounts
         ?.filter(account => {
+          // Normalize to lowercase for case-insensitive comparison since plain addresses from CAIP may vary in casing
           const accountAddress = NetworkUtil.getPlainAddress(account)?.toLowerCase();
 
           return (

--- a/packages/common/src/adapters/BlockchainAdapter.ts
+++ b/packages/common/src/adapters/BlockchainAdapter.ts
@@ -79,16 +79,25 @@ export abstract class BlockchainAdapter extends EventEmitter {
 
   onAccountsChanged(accounts: string[]): void {
     const _accounts = this.getAccounts();
+    // Normalize incoming accounts to lowercase for case-insensitive comparison
+    const normalizedIncomingAccounts = accounts.map(addr => addr.toLowerCase());
+
+    // Filter: Keep only adapter accounts (CAIP) whose plain address is in the incoming accounts array
     const updatedAccounts =
       _accounts
         ?.filter(account => {
-          const accountAddress = NetworkUtil.getPlainAddress(account);
+          const accountAddress = NetworkUtil.getPlainAddress(account)?.toLowerCase();
 
-          return accountAddress !== undefined && accounts.includes(accountAddress);
+          return (
+            accountAddress !== undefined && normalizedIncomingAccounts.includes(accountAddress)
+          );
         })
-        ?.sort((a, b) => {
-          const aIndex = accounts.indexOf(NetworkUtil.getPlainAddress(a) ?? '');
-          const bIndex = accounts.indexOf(NetworkUtil.getPlainAddress(b) ?? '');
+        // Sort: Maintain the order from the incoming accounts parameter
+        .sort((a, b) => {
+          const aAddress = NetworkUtil.getPlainAddress(a)?.toLowerCase() ?? '';
+          const bAddress = NetworkUtil.getPlainAddress(b)?.toLowerCase() ?? '';
+          const aIndex = normalizedIncomingAccounts.indexOf(aAddress);
+          const bIndex = normalizedIncomingAccounts.indexOf(bAddress);
 
           return aIndex - bIndex;
         }) ?? [];

--- a/packages/core/src/controllers/ConnectionsController.ts
+++ b/packages/core/src/controllers/ConnectionsController.ts
@@ -391,7 +391,7 @@ export const ConnectionsController = {
     return getActiveAddress(newConnection);
   },
 
-  getActiveNetwork(namespace?: ChainNamespace) {
+  getActiveNetworkId(namespace?: ChainNamespace) {
     const connection = namespace
       ? baseState.connections.get(namespace)
       : getActiveConnection(baseState);

--- a/packages/core/src/controllers/ConnectionsController.ts
+++ b/packages/core/src/controllers/ConnectionsController.ts
@@ -391,6 +391,15 @@ export const ConnectionsController = {
     return getActiveAddress(newConnection);
   },
 
+  getActiveNetwork(namespace?: ChainNamespace) {
+    const connection = namespace
+      ? baseState.connections.get(namespace)
+      : getActiveConnection(baseState);
+    if (!connection) return undefined;
+
+    return connection.caipNetwork;
+  },
+
   async disconnect(namespace: ChainNamespace, isInternal = true) {
     const connection = baseState.connections.get(namespace);
     if (!connection) return;

--- a/packages/core/src/utils/FetchUtil.ts
+++ b/packages/core/src/utils/FetchUtil.ts
@@ -134,7 +134,7 @@ export class FetchUtil {
     if (!response.ok) {
       if (response.headers.get('content-type')?.includes('application/json')) {
         try {
-          const errorData = await response.json();
+          const errorData = JSON.stringify(await response.json());
           LogController.sendError(errorData, 'FetchUtil.ts', 'processResponse');
 
           return Promise.reject(errorData);

--- a/packages/core/src/utils/FetchUtil.ts
+++ b/packages/core/src/utils/FetchUtil.ts
@@ -134,8 +134,8 @@ export class FetchUtil {
     if (!response.ok) {
       if (response.headers.get('content-type')?.includes('application/json')) {
         try {
-          const errorData = JSON.stringify(await response.json());
-          LogController.sendError(errorData, 'FetchUtil.ts', 'processResponse');
+          const errorData = await response.json();
+          LogController.sendError(JSON.stringify(errorData), 'FetchUtil.ts', 'processResponse');
 
           return Promise.reject(errorData);
         } catch (jsonError) {

--- a/packages/wagmi/src/adapter.ts
+++ b/packages/wagmi/src/adapter.ts
@@ -149,6 +149,12 @@ export class WagmiAdapter extends EVMAdapter {
     return WagmiAdapter.supportedNamespace;
   }
 
+  // Override subscribeToEvents to prevent double subscription
+  // Wagmi handles provider events through its connector system and watchAccount
+  override subscribeToEvents(): void {
+    // Do nothing - wagmi's watchAccount in setupWatchers handles all events
+  }
+
   override init({ connector: _connector }: BlockchainAdapterInitParams): void {
     super.init({ connector: _connector });
 
@@ -184,11 +190,24 @@ export class WagmiAdapter extends EVMAdapter {
   setupWatchers() {
     watchAccount(this.wagmiConfig, {
       onChange: (accountData, prevAccountData) => {
+        // Handle disconnect
         if (accountData.status === 'disconnected' && prevAccountData.address) {
           this.onDisconnect();
+
+          return;
         }
 
-        if (accountData?.chainId && accountData?.chainId !== prevAccountData?.chainId) {
+        // Handle account address changes
+        if (
+          accountData?.addresses &&
+          accountData?.address &&
+          accountData.address !== prevAccountData?.address
+        ) {
+          this.onAccountsChanged([...accountData.addresses]);
+        }
+
+        // Handle chain changes
+        if (accountData?.chainId && accountData.chainId !== prevAccountData?.chainId) {
           this.onChainChanged(accountData.chainId?.toString());
         }
       }

--- a/packages/wagmi/src/adapter.ts
+++ b/packages/wagmi/src/adapter.ts
@@ -34,6 +34,7 @@ export class WagmiAdapter extends EVMAdapter {
   public wagmiChains: readonly Chain[] | undefined;
   public wagmiConfig!: Config;
   private wagmiConfigConnector?: Connector;
+  private unsubscribeWatchAccount?: () => void;
 
   constructor(configParams: ConfigParams) {
     super({
@@ -131,6 +132,11 @@ export class WagmiAdapter extends EVMAdapter {
   }
 
   async disconnect(): Promise<void> {
+    if (this.unsubscribeWatchAccount) {
+      this.unsubscribeWatchAccount();
+      this.unsubscribeWatchAccount = undefined;
+    }
+
     if (this.wagmiConfigConnector) {
       await disconnectWagmiCore(this.wagmiConfig, { connector: this.wagmiConfigConnector });
       this.wagmiConfigConnector = undefined;
@@ -188,8 +194,13 @@ export class WagmiAdapter extends EVMAdapter {
   }
 
   setupWatchers() {
-    watchAccount(this.wagmiConfig, {
+    // Clean up existing subscription if any
+    this.unsubscribeWatchAccount?.();
+
+    this.unsubscribeWatchAccount = watchAccount(this.wagmiConfig, {
       onChange: (accountData, prevAccountData) => {
+        if (!this.connector) return;
+
         // Handle disconnect
         if (accountData.status === 'disconnected' && prevAccountData.address) {
           this.onDisconnect();

--- a/packages/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/wagmi/src/connectors/UniversalConnector.ts
@@ -31,6 +31,25 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
   let sessionDelete: UniversalConnector['onSessionDelete'] | undefined;
   let disconnect: UniversalConnector['onDisconnect'] | undefined;
 
+  function cleanupEventListeners(_provider?: Provider | null) {
+    if (accountsChanged) {
+      _provider?.off('accountsChanged', accountsChanged);
+      accountsChanged = undefined;
+    }
+    if (chainChanged) {
+      _provider?.off('chainChanged', chainChanged);
+      chainChanged = undefined;
+    }
+    if (disconnect) {
+      _provider?.off('disconnect', disconnect);
+      disconnect = undefined;
+    }
+    if (sessionDelete) {
+      _provider?.off('session_delete', sessionDelete);
+      sessionDelete = undefined;
+    }
+  }
+
   return createConnector<Provider, Properties>(config => ({
     id: 'walletconnect',
     name: 'WalletConnect',
@@ -103,22 +122,7 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
           throw error;
         }
       } finally {
-        if (chainChanged) {
-          _provider?.off('chainChanged', chainChanged);
-          chainChanged = undefined;
-        }
-        if (disconnect) {
-          _provider?.off('disconnect', disconnect);
-          disconnect = undefined;
-        }
-        if (accountsChanged) {
-          _provider?.off('accountsChanged', accountsChanged);
-          accountsChanged = undefined;
-        }
-        if (sessionDelete) {
-          _provider?.off('session_delete', sessionDelete);
-          sessionDelete = undefined;
-        }
+        cleanupEventListeners(_provider);
       }
     },
 
@@ -248,39 +252,11 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
 
       try {
         const _provider = await this.getProvider();
-
-        // Clean up event listeners
-        if (accountsChanged) {
-          _provider.off('accountsChanged', accountsChanged);
-          accountsChanged = undefined;
-        }
-        if (chainChanged) {
-          _provider.off('chainChanged', chainChanged);
-          chainChanged = undefined;
-        }
-        if (disconnect) {
-          _provider.off('disconnect', disconnect);
-          disconnect = undefined;
-        }
-        if (sessionDelete) {
-          _provider.off('session_delete', sessionDelete);
-          sessionDelete = undefined;
-        }
+        cleanupEventListeners(_provider);
       } catch (error) {
         // If provider is not available, still clean up local references
         // to prevent memory leaks
-        if (accountsChanged) {
-          accountsChanged = undefined;
-        }
-        if (chainChanged) {
-          chainChanged = undefined;
-        }
-        if (disconnect) {
-          disconnect = undefined;
-        }
-        if (sessionDelete) {
-          sessionDelete = undefined;
-        }
+        cleanupEventListeners(null);
       }
     },
 

--- a/packages/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/wagmi/src/connectors/UniversalConnector.ts
@@ -226,9 +226,11 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
       //Only emit if the account is an evm account
       const shouldEmit = accounts.some(account => account.startsWith('0x'));
 
-      if (accounts.length === 0) this.onDisconnect();
-      else if (shouldEmit)
+      if (accounts.length === 0) {
+        this.onDisconnect();
+      } else if (shouldEmit) {
         config.emitter.emit('change', { accounts: accounts.map(x => getAddress(x)) });
+      }
     },
 
     onChainChanged(chain: string) {

--- a/packages/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/wagmi/src/connectors/UniversalConnector.ts
@@ -128,8 +128,7 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
 
     async getAccounts() {
       const namespaces = appKitProvidedConnector.getNamespaces();
-      // @ts-ignore
-      const eip155Accounts = namespaces?.eip155?.accounts;
+      const eip155Accounts = namespaces?.['eip155']?.accounts as string[] | undefined;
       if (!eip155Accounts) return [] as readonly Hex[];
 
       return eip155Accounts
@@ -149,8 +148,7 @@ export function UniversalConnector(appKitProvidedConnector: WalletConnector) {
 
       // Fallback: Try to get from CAIP accounts if available
       const namespaces = appKitProvidedConnector.getNamespaces();
-      // @ts-ignore
-      const eip155Accounts = namespaces?.eip155?.accounts;
+      const eip155Accounts = namespaces?.['eip155']?.accounts as string[] | undefined;
       if (eip155Accounts && eip155Accounts.length > 0) {
         const parts = eip155Accounts[0]?.split(':');
         if (parts && parts.length > 1 && typeof parts[1] === 'string') {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to account management, event handling, and authentication flows across the appkit and wagmi packages. The key changes include making account comparisons case-insensitive, refining event subscriptions in the wagmi adapter, and improving how active networks are tracked and updated. Additionally, the authentication user experience is enhanced by ensuring loading indicators display at the correct time.

**Account and Network Management Improvements:**

* Made account address comparisons case-insensitive and ensured the order of accounts matches the order provided by wallet connectors in `BlockchainAdapter.onAccountsChanged`, reducing bugs from address casing mismatches.
* Added `ConnectionsController.getActiveNetwork` to retrieve the currently active network for a namespace, and updated `AppKit` to avoid unnecessary active network updates. [[1]](diffhunk://#diff-68c9947de03833ee5f6205e289907e422a90b7028de3f64f125e9165882f7079R394-R402) [[2]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559R636-R642)

**Event Handling and Adapter Updates:**

* Overrode `subscribeToEvents` in `WagmiAdapter` to prevent double event subscriptions, relying on wagmi's internal mechanisms, and improved watcher logic to handle disconnects, account, and chain changes more robustly. [[1]](diffhunk://#diff-36cb0cee17fe8afb20c708564c241fc06e5522cbba7faa2c809283d7be6534afR152-R157) [[2]](diffhunk://#diff-36cb0cee17fe8afb20c708564c241fc06e5522cbba7faa2c809283d7be6534afR193-R210)
* Improved account change handling in `UniversalConnector` to ensure disconnects are properly triggered and account changes are emitted only for EVM accounts.

**Authentication Flow Enhancements:**

* Moved the loading indicator in `SIWXUtil` to display only after a successful authentication result, preventing premature loading messages and improving user experience. [[1]](diffhunk://#diff-dc4827cb6b5465890d57ca1f8a7d36596486f96e8b4b0915a89fc0a3576dc65cL296-L297) [[2]](diffhunk://#diff-dc4827cb6b5465890d57ca1f8a7d36596486f96e8b4b0915a89fc0a3576dc65cR321)
* Updated `AppKit` to pass a `closeModal` flag to `SIWXUtil.initializeIfEnabled` based on the current view, improving modal handling during authentication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids duplicate Wagmi event subscriptions, normalizes account comparisons/order, improves unsupported-chain and SIWX auth handling, and tightens error/log behavior.
> 
> - **Adapters/Events**:
>   - `packages/wagmi/src/adapter.ts`: Add watcher unsubscribe, override `subscribeToEvents` to no-op, and refine `watchAccount` to handle disconnects, account, and chain changes.
>   - `packages/wagmi/src/connectors/UniversalConnector.ts`: Centralize listener cleanup, improve EVM-only emissions, and tighten types for namespaces.
> - **Accounts/Networks**:
>   - `packages/common/src/adapters/BlockchainAdapter.ts`: Make account comparisons case-insensitive and preserve incoming order in `onAccountsChanged`.
>   - `packages/core/src/controllers/ConnectionsController.ts`: Add `getActiveNetworkId` to read current CAIP network.
>   - `packages/appkit/src/AppKit.ts`: On `chainChanged`, skip redundant active-network updates; pass `closeModal` to `SIWXUtil.initializeIfEnabled` when appropriate.
> - **SIWX/Auth UX**:
>   - `packages/appkit/src/utils/SIWXUtil.ts`: Remove native alert, use snack errors; adjust loading to show only after auth results and ensure hide on error; tweak universal auth loading timing.
> - **Utils**:
>   - `packages/core/src/utils/FetchUtil.ts`: Log JSON error bodies as strings in `processResponse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 157bcc5df9ed2a9d22753fd98acb2e819e12e194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->