### PR TITLE
chore: removed dev check from LogController

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -688,8 +688,6 @@ export class AppKit {
     OptionsController.setEnableAnalytics(options.enableAnalytics);
     OptionsController.setDebug(options.debug && __DEV__);
 
-    // Initialize LogController after debug option is set
-    LogController.initialize();
     LogController.sendInfo('AppKit initialization started', 'AppKit.ts', 'initControllers', {
       projectId: options.projectId,
       adapters: this.adapters.map(a => a.constructor.name),

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -686,7 +686,7 @@ export class AppKit {
     this.setCustomWallets(options);
     OptionsController.setFeaturedWalletIds(options.featuredWalletIds);
     OptionsController.setEnableAnalytics(options.enableAnalytics);
-    OptionsController.setDebug(options.debug && __DEV__);
+    OptionsController.setDebug(options.debug);
 
     LogController.sendInfo('AppKit initialization started', 'AppKit.ts', 'initControllers', {
       projectId: options.projectId,

--- a/packages/core/src/__tests__/controllers/LogController.test.ts
+++ b/packages/core/src/__tests__/controllers/LogController.test.ts
@@ -25,7 +25,6 @@ describe('LogController', () => {
 
   describe('Basic Logging', () => {
     it('should initialize correctly', () => {
-      LogController.initialize();
       expect(LogController.state.logs).toEqual([]);
     });
 
@@ -240,7 +239,6 @@ describe('LogController', () => {
   describe('Concurrent Access Patterns', () => {
     beforeEach(() => {
       LogController.clearLogs();
-      LogController.initialize();
       OptionsController.setDebug(true);
     });
 
@@ -365,7 +363,6 @@ describe('LogController', () => {
   describe('Memory Cleanup Under Load', () => {
     beforeEach(() => {
       LogController.clearLogs();
-      LogController.initialize();
       OptionsController.setDebug(true);
     });
 
@@ -429,7 +426,6 @@ describe('LogController', () => {
   describe('Malformed Error Objects', () => {
     beforeEach(() => {
       LogController.clearLogs();
-      LogController.initialize();
       OptionsController.setDebug(true);
     });
 

--- a/packages/core/src/controllers/LogController.ts
+++ b/packages/core/src/controllers/LogController.ts
@@ -91,7 +91,7 @@ export const LogController = {
     data?: Record<string, unknown>
   ) {
     if (!OptionsController.state.debug) {
-      return; // Logs were not stored when debug=false
+      return;
     }
     const entry: LogEntry = {
       id: generateLogId(),

--- a/packages/core/src/controllers/LogController.ts
+++ b/packages/core/src/controllers/LogController.ts
@@ -73,13 +73,6 @@ export const LogController = {
   state,
 
   /**
-   * Initialize the LogController
-   */
-  initialize() {
-    // Initialize the LogController
-  },
-
-  /**
    * Destroy the LogController (cleanup resources)
    */
   destroy() {
@@ -97,10 +90,6 @@ export const LogController = {
     functionName?: string,
     data?: Record<string, unknown>
   ) {
-    if (!OptionsController.state.debug) {
-      return;
-    }
-
     const entry: LogEntry = {
       id: generateLogId(),
       timestamp: Date.now(),

--- a/packages/core/src/controllers/LogController.ts
+++ b/packages/core/src/controllers/LogController.ts
@@ -90,6 +90,9 @@ export const LogController = {
     functionName?: string,
     data?: Record<string, unknown>
   ) {
+    if (!OptionsController.state.debug) {
+      return; // Logs were not stored when debug=false
+    }
     const entry: LogEntry = {
       id: generateLogId(),
       timestamp: Date.now(),


### PR DESCRIPTION
This pull request removes the now-unnecessary `initialize` method from the `LogController` and updates related code and tests accordingly. The changes simplify the logging infrastructure by eliminating redundant initialization logic and associated calls.

**Logging infrastructure simplification:**

* Removed the `initialize` method from `LogController` and all calls to it across the codebase and tests, as it no longer performs any setup. [[1]](diffhunk://#diff-88fc88685fe311e236dac0bcc6cc0d57c453e189a560c335cec82ab03ec3737dL75-L81) [[2]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559L691-L692) [[3]](diffhunk://#diff-403a90edc3c03c001ea8c29b3761f821ce90ee5080971f788be0ef1119a4cbd7L28) [[4]](diffhunk://#diff-403a90edc3c03c001ea8c29b3761f821ce90ee5080971f788be0ef1119a4cbd7L243) [[5]](diffhunk://#diff-403a90edc3c03c001ea8c29b3761f821ce90ee5080971f788be0ef1119a4cbd7L368) [[6]](diffhunk://#diff-403a90edc3c03c001ea8c29b3761f821ce90ee5080971f788be0ef1119a4cbd7L432)

**Code cleanup:**

* Removed the debug check from the `sendInfo` method in `LogController`, making log sending unconditional (likely because debug checks are now handled elsewhere).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `LogController.initialize` and its test usages, and sets `OptionsController.debug` directly from options without `__DEV__` gating.
> 
> - **Core**:
>   - **LogController**: Removes `initialize()` and related no-op; retains cleanup via `destroy()`.
> - **Tests**:
>   - Update `packages/core/src/__tests__/controllers/LogController.test.ts` to drop all `LogController.initialize()` calls across suites.
> - **AppKit**:
>   - In `packages/appkit/src/AppKit.ts`, set `OptionsController.setDebug(options.debug)` (remove `&& __DEV__`) and remove `LogController.initialize()` during controller init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7ca30bbddd8a3695db0ce77408988afa1a2e4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->