### PR TITLE
chore: wallet impression event

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -214,6 +214,7 @@ export class AppKit {
       SendController.resetState();
       OnRampController.resetState();
       WcController.resetState();
+      EventsController.sendWalletImpressions();
 
       if (ConnectionsController.state.activeNamespace === undefined) {
         ConnectionsController.setActiveNamespace(
@@ -308,6 +309,7 @@ export class AppKit {
 
     RouterUtil.checkOnRampBack();
     RouterUtil.checkSocialLoginBack();
+    EventsController.sendWalletImpressions();
   }
 
   back() {

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -214,7 +214,7 @@ export class AppKit {
       SendController.resetState();
       OnRampController.resetState();
       WcController.resetState();
-      EventsController.sendWalletImpressions();
+      EventsController.resetState();
 
       if (ConnectionsController.state.activeNamespace === undefined) {
         ConnectionsController.setActiveNamespace(

--- a/packages/appkit/src/partials/w3m-all-wallets-list/components/WalletList.tsx
+++ b/packages/appkit/src/partials/w3m-all-wallets-list/components/WalletList.tsx
@@ -85,7 +85,7 @@ export function WalletList({
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
       if (isLoading) return;
 
-      viewableItems.forEach(({ item, index }) => {
+      viewableItems.forEach(({ item }, index) => {
         const wallet = item as WcWallet;
         if (wallet?.id && !viewedWalletsRef.current.has(wallet.id)) {
           viewedWalletsRef.current.add(wallet.id);
@@ -93,7 +93,7 @@ export function WalletList({
           EventsController.trackWalletImpression({
             wallet,
             view: 'AllWallets',
-            displayIndex: index ?? 0,
+            displayIndex: index,
             query: searchQuery,
             installed: isInstalled
           });

--- a/packages/appkit/src/partials/w3m-all-wallets-list/components/WalletList.tsx
+++ b/packages/appkit/src/partials/w3m-all-wallets-list/components/WalletList.tsx
@@ -1,4 +1,4 @@
-import { FlatList, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { FlatList, StyleSheet, type StyleProp, type ViewStyle, type ViewToken } from 'react-native';
 import { WalletItem } from './WalletItem';
 import {
   CardSelectHeight,
@@ -7,8 +7,9 @@ import {
   CardSelectLoader,
   CardSelectWidth
 } from '@reown/appkit-ui-react-native';
-import { ApiController } from '@reown/appkit-core-react-native';
+import { ApiController, EventsController } from '@reown/appkit-core-react-native';
 import type { WcWallet } from '@reown/appkit-common-react-native';
+import { useCallback, useRef } from 'react';
 
 const imageHeaders = ApiController._getApiHeaders();
 
@@ -25,6 +26,7 @@ interface Props {
   loadingItems?: number;
   style?: StyleProp<ViewStyle>;
   testIDKey?: string;
+  searchQuery?: string;
 }
 
 export function WalletList({
@@ -35,14 +37,76 @@ export function WalletList({
   isLoading = false,
   loadingItems = 20,
   testIDKey,
-  style
+  style,
+  searchQuery
 }: Props) {
   const { padding, maxHeight } = useCustomDimensions();
+  const viewedWalletsRef = useRef<Set<string>>(new Set());
 
   // Create loading data if isLoading is true
   const displayData = isLoading
     ? Array.from({ length: loadingItems }, (_, index) => ({ id: `loading-${index}` }) as WcWallet)
     : data;
+
+  const keyExtractor = useCallback(
+    (item: WcWallet, index: number) => item?.id ?? `item-${index}`,
+    []
+  );
+
+  const getItemLayout = useCallback((_: any, index: number) => {
+    return {
+      length: ITEM_HEIGHT_WITH_GAP,
+      offset: ITEM_HEIGHT_WITH_GAP * index,
+      index
+    };
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: WcWallet; index: number }) => {
+      if (isLoading) {
+        return <CardSelectLoader style={styles.itemContainer} />;
+      }
+
+      return (
+        <WalletItem
+          item={item}
+          imageHeaders={imageHeaders}
+          displayIndex={index}
+          onItemPress={onItemPress}
+          style={styles.itemContainer}
+          testID={testIDKey ? `${testIDKey}-${item?.id}` : undefined}
+        />
+      );
+    },
+    [isLoading, onItemPress, testIDKey]
+  );
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (isLoading) return;
+
+      viewableItems.forEach(({ item, index }) => {
+        const wallet = item as WcWallet;
+        if (wallet?.id && !viewedWalletsRef.current.has(wallet.id)) {
+          viewedWalletsRef.current.add(wallet.id);
+          const isInstalled = !!ApiController.state.installed.find(w => w?.id === item?.id);
+          EventsController.trackWalletImpression({
+            wallet,
+            view: 'AllWallets',
+            displayIndex: index ?? 0,
+            query: searchQuery,
+            installed: isInstalled
+          });
+        }
+      });
+    },
+    [isLoading, searchQuery]
+  );
+
+  const viewabilityConfig = useRef({
+    itemVisiblePercentThreshold: 50, // Item is considered visible when 50% is visible
+    minimumViewTime: 100 // Must be visible for at least 100ms
+  }).current;
 
   return (
     <FlatList
@@ -52,34 +116,18 @@ export function WalletList({
       data={displayData}
       style={[styles.list, { height: maxHeight }, style]}
       columnWrapperStyle={styles.columnWrapperStyle}
-      renderItem={({ item, index }) => {
-        if (isLoading) {
-          return <CardSelectLoader style={styles.itemContainer} />;
-        }
-
-        return (
-          <WalletItem
-            item={item}
-            imageHeaders={imageHeaders}
-            displayIndex={index}
-            onItemPress={onItemPress}
-            style={styles.itemContainer}
-            testID={testIDKey ? `${testIDKey}-${item?.id}` : undefined}
-          />
-        );
-      }}
+      renderItem={renderItem}
       contentContainerStyle={[styles.contentContainer, { paddingHorizontal: padding }]}
       initialNumToRender={32}
       maxToRenderPerBatch={12}
       windowSize={10}
       onEndReached={onEndReached}
       onEndReachedThreshold={onEndReachedThreshold}
-      keyExtractor={(item, index) => item?.id ?? `item-${index}`}
-      getItemLayout={(_, index) => ({
-        length: ITEM_HEIGHT_WITH_GAP,
-        offset: ITEM_HEIGHT_WITH_GAP * index,
-        index
-      })}
+      keyExtractor={keyExtractor}
+      removeClippedSubviews={true}
+      getItemLayout={getItemLayout}
+      onViewableItemsChanged={onViewableItemsChanged}
+      viewabilityConfig={viewabilityConfig}
     />
   );
 }

--- a/packages/appkit/src/partials/w3m-all-wallets-list/index.tsx
+++ b/packages/appkit/src/partials/w3m-all-wallets-list/index.tsx
@@ -116,7 +116,7 @@ export function AllWalletsList({ onItemPress }: AllWalletsListProps) {
     <WalletList
       data={walletList}
       onEndReached={fetchNextPage}
-      onEndReachedThreshold={2}
+      onEndReachedThreshold={0.5}
       onItemPress={onItemPress}
     />
   );

--- a/packages/appkit/src/partials/w3m-all-wallets-search/index.tsx
+++ b/packages/appkit/src/partials/w3m-all-wallets-search/index.tsx
@@ -84,5 +84,12 @@ export function AllWalletsSearch({ searchQuery, onItemPress }: AllWalletsSearchP
     );
   }
 
-  return <WalletList onItemPress={onItemPress} data={results} testIDKey="wallet-search-item" />;
+  return (
+    <WalletList
+      onItemPress={onItemPress}
+      searchQuery={searchQuery}
+      data={results}
+      testIDKey="wallet-search-item"
+    />
+  );
 }

--- a/packages/appkit/src/views/w3m-connect-view/components/all-wallet-list.tsx
+++ b/packages/appkit/src/views/w3m-connect-view/components/all-wallet-list.tsx
@@ -4,6 +4,7 @@ import {
   ApiController,
   AssetController,
   AssetUtil,
+  EventsController,
   OptionsController,
   WcController,
   type WcControllerState
@@ -11,6 +12,7 @@ import {
 import { type WcWallet } from '@reown/appkit-common-react-native';
 import { ListItemLoader, ListWallet } from '@reown/appkit-ui-react-native';
 import { UiUtil } from '../../../utils/UiUtil';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   itemStyle: StyleProp<ViewStyle>;
@@ -24,6 +26,9 @@ export function AllWalletList({ itemStyle, onWalletPress }: Props) {
   const { walletImages } = useSnapshot(AssetController.state);
   const imageHeaders = ApiController._getApiHeaders();
 
+  // Track which wallets have been tracked to prevent duplicates
+  const trackedWalletsRef = useRef<Set<string>>(new Set());
+
   const combinedWallets = [
     ...(recentWallets?.slice(0, 1) ?? []),
     ...installed,
@@ -36,6 +41,27 @@ export function AllWalletList({ itemStyle, onWalletPress }: Props) {
   const list = Array.from(
     new Map(combinedWallets.map(wallet => [wallet.id, wallet])).values()
   ).slice(0, UiUtil.TOTAL_VISIBLE_WALLETS);
+
+  // Track impressions once when the list stabilizes
+  useEffect(() => {
+    if (!prefetchLoading && list.length > 0) {
+      list.forEach((wallet, index) => {
+        if (!trackedWalletsRef.current.has(wallet.id)) {
+          trackedWalletsRef.current.add(wallet.id);
+          const isInstalled = !!ApiController.state.installed.find(
+            installedWallet => installedWallet.id === wallet.id
+          );
+          EventsController.trackWalletImpression({
+            wallet,
+            view: 'Connect',
+            displayIndex: index,
+            // eslint-disable-next-line valtio/state-snapshot-rule
+            installed: isInstalled
+          });
+        }
+      });
+    }
+  }, [prefetchLoading, list]);
 
   if (!list?.length) {
     return null;

--- a/packages/appkit/src/views/w3m-connect-view/components/all-wallet-list.tsx
+++ b/packages/appkit/src/views/w3m-connect-view/components/all-wallet-list.tsx
@@ -12,7 +12,7 @@ import {
 import { type WcWallet } from '@reown/appkit-common-react-native';
 import { ListItemLoader, ListWallet } from '@reown/appkit-ui-react-native';
 import { UiUtil } from '../../../utils/UiUtil';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 interface Props {
   itemStyle: StyleProp<ViewStyle>;
@@ -29,18 +29,21 @@ export function AllWalletList({ itemStyle, onWalletPress }: Props) {
   // Track which wallets have been tracked to prevent duplicates
   const trackedWalletsRef = useRef<Set<string>>(new Set());
 
-  const combinedWallets = [
-    ...(recentWallets?.slice(0, 1) ?? []),
-    ...installed,
-    ...featured,
-    ...recommended,
-    ...(customWallets ?? [])
-  ];
+  const list = useMemo(() => {
+    const combinedWallets = [
+      ...(recentWallets?.slice(0, 1) ?? []),
+      ...installed,
+      ...featured,
+      ...recommended,
+      ...(customWallets ?? [])
+    ];
 
-  // Deduplicate by wallet ID
-  const list = Array.from(
-    new Map(combinedWallets.map(wallet => [wallet.id, wallet])).values()
-  ).slice(0, UiUtil.TOTAL_VISIBLE_WALLETS);
+    // Deduplicate by wallet ID
+    return Array.from(new Map(combinedWallets.map(wallet => [wallet.id, wallet])).values()).slice(
+      0,
+      UiUtil.TOTAL_VISIBLE_WALLETS
+    );
+  }, [recentWallets, installed, featured, recommended, customWallets]);
 
   // Track impressions once when the list stabilizes
   useEffect(() => {

--- a/packages/common/src/types/api/events.ts
+++ b/packages/common/src/types/api/events.ts
@@ -10,6 +10,17 @@ import type {
 import type { Features } from '../ui';
 import type { Metadata } from '../wallet';
 
+export type WalletImpressionItem = {
+  name: string;
+  walletRank: number | undefined;
+  explorerId: string;
+  view: 'Connect' | 'AllWallets';
+  displayIndex?: number;
+  query?: string;
+  certified?: boolean;
+  installed?: boolean;
+};
+
 export type EventName =
   | 'MODAL_LOADED'
   | 'MODAL_OPEN'
@@ -442,4 +453,9 @@ export type Event =
       properties?: {
         message?: string;
       };
+    }
+  | {
+      type: 'track';
+      event: 'WALLET_IMPRESSION';
+      items: Array<WalletImpressionItem>;
     };

--- a/packages/common/src/types/api/events.ts
+++ b/packages/common/src/types/api/events.ts
@@ -26,6 +26,7 @@ export type EventName =
   | 'MODAL_OPEN'
   | 'MODAL_CLOSE'
   | 'INITIALIZE'
+  | 'WALLET_IMPRESSION'
   | 'CLICK_ALL_WALLETS'
   | 'CLICK_NETWORKS'
   | 'SWITCH_NETWORK'

--- a/packages/core/src/controllers/EventsController.ts
+++ b/packages/core/src/controllers/EventsController.ts
@@ -125,5 +125,18 @@ export const EventsController = {
     if (OptionsController.state.enableAnalytics) {
       EventsController._sendAnalyticsEvent(data, timestamp);
     }
+  },
+
+  resetState() {
+    if (state.pendingImpressionTimeout) {
+      clearTimeout(state.pendingImpressionTimeout);
+      state.pendingImpressionTimeout = undefined;
+    }
+    state.pendingWalletImpressions = [];
+    state.data = {
+      type: 'track',
+      event: 'MODAL_CREATED'
+    };
+    state.timestamp = Date.now();
   }
 };

--- a/packages/core/src/controllers/EventsController.ts
+++ b/packages/core/src/controllers/EventsController.ts
@@ -85,13 +85,17 @@ export const EventsController = {
     }
 
     const impressions = state.pendingWalletImpressions;
+
+    if (impressions.length === 0) {
+      return;
+    }
+
+    state.pendingWalletImpressions = [];
     EventsController.sendEvent({
       type: 'track',
       event: 'WALLET_IMPRESSION',
       items: impressions
     });
-
-    state.pendingWalletImpressions = [];
   },
 
   async _sendAnalyticsEvent(data: EventsControllerState['data'], timestamp: number) {

--- a/packages/core/src/controllers/EventsController.ts
+++ b/packages/core/src/controllers/EventsController.ts
@@ -3,17 +3,25 @@ import { ApiController } from './ApiController';
 import { OptionsController } from './OptionsController';
 import { CoreHelperUtil } from '../utils/CoreHelperUtil';
 import { FetchUtil } from '../utils/FetchUtil';
-import type { Event, EventName } from '@reown/appkit-common-react-native';
+import type {
+  Event,
+  EventName,
+  WalletImpressionItem,
+  WcWallet
+} from '@reown/appkit-common-react-native';
 
 // -- Helpers ------------------------------------------- //
 const baseUrl = CoreHelperUtil.getAnalyticsUrl();
 const api = new FetchUtil({ baseUrl });
 const excluded = ['MODAL_CREATED'];
+const IMPRESSION_TIMEOUT = 3000;
 
 // -- Types --------------------------------------------- //
 export interface EventsControllerState {
   timestamp: number;
   data: Event;
+  pendingWalletImpressions: WalletImpressionItem[];
+  pendingImpressionTimeout?: NodeJS.Timeout;
 }
 
 // -- State --------------------------------------------- //
@@ -22,7 +30,9 @@ const state = proxy<EventsControllerState>({
   data: {
     type: 'track',
     event: 'MODAL_CREATED' // just for init purposes
-  }
+  },
+  pendingWalletImpressions: [],
+  pendingImpressionTimeout: undefined
 });
 
 // -- Controller ---------------------------------------- //
@@ -39,6 +49,49 @@ export const EventsController = {
         callback(state);
       }
     });
+  },
+
+  trackWalletImpression(props: {
+    wallet: WcWallet;
+    view: 'Connect' | 'AllWallets';
+    displayIndex: number;
+    query?: string;
+    installed?: boolean;
+  }) {
+    state.pendingWalletImpressions.push({
+      name: props.wallet.name ?? 'Unknown',
+      walletRank: props.wallet.order,
+      explorerId: props.wallet.id,
+      certified: props.wallet.badge_type === 'certified',
+      displayIndex: props.displayIndex,
+      view: props.view,
+      query: props.query,
+      installed: props.installed
+    });
+
+    if (state.pendingImpressionTimeout) {
+      clearTimeout(state.pendingImpressionTimeout);
+    }
+
+    state.pendingImpressionTimeout = setTimeout(() => {
+      EventsController.sendWalletImpressions();
+    }, IMPRESSION_TIMEOUT);
+  },
+
+  sendWalletImpressions() {
+    if (state.pendingImpressionTimeout) {
+      clearTimeout(state.pendingImpressionTimeout);
+      state.pendingImpressionTimeout = undefined;
+    }
+
+    const impressions = state.pendingWalletImpressions;
+    EventsController.sendEvent({
+      type: 'track',
+      event: 'WALLET_IMPRESSION',
+      items: impressions
+    });
+
+    state.pendingWalletImpressions = [];
   },
 
   async _sendAnalyticsEvent(data: EventsControllerState['data'], timestamp: number) {


### PR DESCRIPTION
This pull request introduces a new wallet impression tracking system to the appkit, enabling analytics on which wallets users view and interact with. The main changes include implementing impression batching and throttling, updating analytics event types, and integrating impression tracking throughout wallet list and search components.

**Wallet Impression Tracking and Analytics Integration:**

* Added a new `WalletImpressionItem` type and extended the analytics event system to support batched wallet impression events, including view context, display index, search query, and install status. [[1]](diffhunk://#diff-f789d781b378dfd9b7662f7eb59d9bf09beb81835145b610622c88fee4652d9cR13-R23) [[2]](diffhunk://#diff-f789d781b378dfd9b7662f7eb59d9bf09beb81835145b610622c88fee4652d9cR456-R460)
* Implemented batching and throttling of wallet impression events in `EventsController`, with a 3-second timeout to send impressions in bulk, reducing analytics noise and improving efficiency. [[1]](diffhunk://#diff-9a03f9d9c907412feabf26f2e9d0f6822c6dca54f07336d2a9f2451e774ceefbL6-R24) [[2]](diffhunk://#diff-9a03f9d9c907412feabf26f2e9d0f6822c6dca54f07336d2a9f2451e774ceefbL25-R35) [[3]](diffhunk://#diff-9a03f9d9c907412feabf26f2e9d0f6822c6dca54f07336d2a9f2451e774ceefbR54-R96)

**Component and UI Integration:**

* Updated `WalletList` and related wallet list/search components to track wallet impressions as users scroll, ensuring impressions are only sent once per wallet per view and include additional context such as search queries. [[1]](diffhunk://#diff-275da98ec305f75b44216ca4660c606614c302c8e8b81291712dda4745964e1aL1-R1) [[2]](diffhunk://#diff-275da98ec305f75b44216ca4660c606614c302c8e8b81291712dda4745964e1aL10-R12) [[3]](diffhunk://#diff-275da98ec305f75b44216ca4660c606614c302c8e8b81291712dda4745964e1aR29) [[4]](diffhunk://#diff-275da98ec305f75b44216ca4660c606614c302c8e8b81291712dda4745964e1aL38-R65) [[5]](diffhunk://#diff-275da98ec305f75b44216ca4660c606614c302c8e8b81291712dda4745964e1aL70-R130) [[6]](diffhunk://#diff-5c5c536ac5b0f235af70fd35736553ad9fb2e76854634f805ed3846e67471b36L87-R94)
* Added impression tracking to the connect view's wallet list, ensuring impressions are sent when the list stabilizes and only for unique wallets. [[1]](diffhunk://#diff-45b700afc164f58032f934df18ba68dc9b781ef62ba41b6ca10299eded30f804R7-R15) [[2]](diffhunk://#diff-45b700afc164f58032f934df18ba68dc9b781ef62ba41b6ca10299eded30f804R29-R31) [[3]](diffhunk://#diff-45b700afc164f58032f934df18ba68dc9b781ef62ba41b6ca10299eded30f804R45-R65)

**Behavioral and UX Adjustments:**

* Ensured wallet impressions are flushed and sent when navigating away from wallet lists or after certain controller resets, preventing impression loss. [[1]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559R217) [[2]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559R312)
* Adjusted the `onEndReachedThreshold` in wallet list pagination for improved UX.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces batched wallet impression analytics with a 3s throttle, integrates impression tracking in wallet lists/search/connect views, and flushes/resets impressions on navigation and disconnect.
> 
> - **Analytics**:
>   - Add `WalletImpressionItem` type and `WALLET_IMPRESSION` event in `packages/common/src/types/api/events.ts`.
>   - Extend `EventsController` (`packages/core/src/controllers/EventsController.ts`) with impression batching (`trackWalletImpression`), 3s timeout, `sendWalletImpressions`, and `resetState`.
> - **App behavior**:
>   - In `packages/appkit/src/AppKit.ts`, reset `EventsController` on disconnect and flush impressions on close/back flows.
> - **UI Integration**:
>   - `WalletList` (`partials/w3m-all-wallets-list/components/WalletList.tsx`): track on-screen wallet impressions (deduped), accept `searchQuery`, and add list performance optimizations (callbacks, `getItemLayout`, `removeClippedSubviews`, viewability config).
>   - `w3m-all-wallets-search`: pass `searchQuery` to `WalletList`.
>   - `connect-view/all-wallet-list.tsx`: track first-render impressions for visible wallets (deduped) with installed status.
>   - Adjust pagination sensitivity: `onEndReachedThreshold` from `2` to `0.5` in `w3m-all-wallets-list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1adc14152d83686627094f2ebcb86462bf35a29f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->