### PR TITLE
fix: added trycatch for safe provider access

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -245,7 +245,7 @@ export class AppKit {
   /**
    * Returns the provider for a given namespace.
    * @param namespace - The namespace to get the provider for.
-   * @returns The provider for the given namespace.
+   * @returns The provider for the given namespace, or null if not available or not yet initialized.
    */
   getProvider<T extends Provider>(namespace?: string): T | null {
     const activeNamespace = namespace ?? ConnectionsController.state.activeNamespace;
@@ -256,7 +256,15 @@ export class AppKit {
     );
     if (!connection || !connection.adapter || !connection.adapter.connector) return null;
 
-    return connection.adapter.connector.getProvider() as T;
+    try {
+      return connection.adapter.connector.getProvider() as T;
+    } catch (error) {
+      // Provider not initialized yet during session restoration
+      // This can happen on app restart when restoring a previous connection
+      LogController.sendError(error, 'AppKit.ts', 'getProvider');
+
+      return null;
+    }
   }
 
   getNetworks() {

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -257,7 +257,7 @@ export class AppKit {
     if (!connection || !connection.adapter || !connection.adapter.connector) return null;
 
     try {
-      return connection.adapter.connector.getProvider() as T;
+      return connection.adapter.connector.getProvider() as T | null;
     } catch (error) {
       // Provider not initialized yet during session restoration
       // This can happen on app restart when restoring a previous connection

--- a/packages/appkit/src/hooks/useProvider.ts
+++ b/packages/appkit/src/hooks/useProvider.ts
@@ -42,10 +42,15 @@ export function useProvider(): ProviderResult {
   const returnValue = useMemo(() => {
     if (!connection) return { provider: undefined, providerType: undefined };
 
-    return {
-      provider: connection.adapter.getProvider(),
-      providerType: connection.adapter.getSupportedNamespace()
-    };
+    try {
+      return {
+        provider: connection.adapter.getProvider(),
+        providerType: connection.adapter.getSupportedNamespace()
+      };
+    } catch (error) {
+      // Provider not initialized yet during session restoration
+      return { provider: undefined, providerType: undefined };
+    }
   }, [connection]);
 
   return returnValue;

--- a/packages/appkit/src/hooks/useProvider.ts
+++ b/packages/appkit/src/hooks/useProvider.ts
@@ -1,7 +1,7 @@
 /* eslint-disable valtio/state-snapshot-rule */
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
-import { ConnectionsController } from '@reown/appkit-core-react-native';
+import { ConnectionsController, LogController } from '@reown/appkit-core-react-native';
 import type { Provider, ChainNamespace } from '@reown/appkit-common-react-native';
 
 /**
@@ -48,6 +48,8 @@ export function useProvider(): ProviderResult {
         providerType: connection.adapter.getSupportedNamespace()
       };
     } catch (error) {
+      LogController.sendError(error, 'useProvider', 'useProvider');
+
       // Provider not initialized yet during session restoration
       return { provider: undefined, providerType: undefined };
     }

--- a/packages/appkit/src/hooks/useProvider.ts
+++ b/packages/appkit/src/hooks/useProvider.ts
@@ -40,7 +40,9 @@ export function useProvider(): ProviderResult {
   const { connection } = useSnapshot(ConnectionsController.state);
 
   const returnValue = useMemo(() => {
-    if (!connection) return { provider: undefined, providerType: undefined };
+    if (!connection || !connection.adapter) {
+      return { provider: undefined, providerType: undefined };
+    }
 
     try {
       return {


### PR DESCRIPTION
This pull request improves the resilience of provider access in the `AppKit` library by handling cases where the provider may not be initialized, such as during session restoration or app restarts. The main changes add error handling and clarify return values to prevent crashes and improve stability.

Error handling and stability improvements:

* Updated the `getProvider` method in `AppKit` to return `null` if the provider is not available or not yet initialized, and added a try/catch block to handle errors gracefully and log them during session restoration scenarios. [[1]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559L248-R248) [[2]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559R259-R267)
* Updated the `useProvider` hook to wrap provider access in a try/catch block, returning `undefined` for the provider and provider type if the provider is not initialized, preventing errors during session restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap provider access in try/catch, return null/undefined when uninitialized, and log errors in `AppKit.getProvider` and `useProvider`.
> 
> - **Provider access resilience**
>   - `packages/appkit/src/AppKit.ts`
>     - `getProvider`: return type clarified to `T | null`; now guards missing connection/adapter and wraps `connector.getProvider()` in try/catch, returning `null` and logging on errors.
>   - `packages/appkit/src/hooks/useProvider.ts`
>     - `useProvider`: adds adapter presence check; wraps `adapter.getProvider()` in try/catch, returning `{ provider: undefined, providerType: undefined }` on failure and logging the error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c9885f3b7c677551a6bf38d51f25665eb784a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->