### PR TITLE
chore: removed yarn install --refresh-lockfile flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "changeset:prepublish": "yarn run clean && yarn install && yarn version:update && yarn run lint && yarn run prettier && yarn run build && yarn run test",
     "changeset:prepublish:ci": "yarn version:update && yarn run lint && yarn run prettier && yarn run build && yarn run test",
     "changeset:publish": "yarn run changeset:prepublish && yarn run changeset publish",
-    "changeset:version": "changeset version; yarn run version:update; yarn install --refresh-lockfile",
+    "changeset:version": "changeset version; yarn run version:update; yarn install",
     "version:update": "./scripts/bump-version.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the --refresh-lockfile flag from the `changeset:version` script in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17516781e6662c2281b720f6d35b3bc09537d47c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->