### PR TITLE
chore: export all connected accounts on useAccount hook

### DIFF
--- a/.changeset/stupid-cloths-admire.md
+++ b/.changeset/stupid-cloths-admire.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+chore: export account list on useAccount hook

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -111,8 +111,8 @@ export function useAccount() {
     allAccounts,
     address: CoreHelperUtil.getPlainAddress(address),
     isConnected: !!address,
-    chainId: activeChain?.id,
-    chain: activeChain as AppKitNetwork,
+    chainId: String(activeChain?.id),
+    chain: activeChain as AppKitNetwork | undefined,
     namespace: activeNamespace
   };
 }

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -7,7 +7,7 @@ import {
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { useAppKit } from './useAppKit';
-import type { AccountType } from '@reown/appkit-common-react-native';
+import type { AccountType, AppKitNetwork } from '@reown/appkit-common-react-native';
 
 /**
  * Represents a blockchain account with its associated metadata
@@ -112,7 +112,7 @@ export function useAccount() {
     address: CoreHelperUtil.getPlainAddress(address),
     isConnected: !!address,
     chainId: activeChain?.id,
-    chain: activeChain,
+    chain: activeChain as AppKitNetwork,
     namespace: activeNamespace
   };
 }

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -1,9 +1,68 @@
 /* eslint-disable valtio/state-snapshot-rule */
-import { ConnectionsController, CoreHelperUtil } from '@reown/appkit-core-react-native';
+import {
+  ConnectionsController,
+  CoreHelperUtil,
+  LogController
+} from '@reown/appkit-core-react-native';
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { useAppKit } from './useAppKit';
+import type { AccountType } from '@reown/appkit-common-react-native';
 
+/**
+ * Represents a blockchain account with its associated metadata
+ */
+export interface Account {
+  /** The blockchain address of the account */
+  address: string;
+  /** The blockchain namespace (e.g., 'eip155' for Ethereum, 'solana' for Solana) */
+  namespace: string;
+  /** The chain ID where this account is active */
+  chainId: string;
+  /** Optional account type (e.g. 'eoa' or 'smartAccount') */
+  type?: AccountType;
+}
+
+/**
+ * Hook to access the current account state and connection information
+ *
+ * @remarks
+ * This hook provides access to all connected accounts, the currently active account,
+ * connection status, and active chain information. It automatically subscribes to
+ * connection state changes via valtio.
+ *
+ * The hook parses account data from CAIP-10 format (namespace:chainId:address)
+ * and provides a normalized structure.
+ *
+ * @returns An object containing:
+ * - `allAccounts` - Array of all connected accounts across all connections
+ * - `address` - The plain address of the currently active account (without namespace or chain prefix)
+ * - `isConnected` - Boolean indicating if a wallet is currently connected
+ * - `chainId` - The ID of the currently active chain
+ * - `chain` - The full chain/network object of the currently active chain
+ * - `namespace` - The namespace of the currently active account (e.g. 'eip155', 'solana' or 'bip122')
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { address, isConnected, chainId, allAccounts } = useAccount();
+ *
+ *   if (!isConnected) {
+ *     return <Text>Not connected</Text>;
+ *   }
+ *
+ *   return (
+ *     <View>
+ *       <Text>Connected: {address}</Text>
+ *       <Text>Chain: {chainId}</Text>
+ *       <Text>Total accounts: {allAccounts.length}</Text>
+ *     </View>
+ *   );
+ * }
+ * ```
+ *
+ * @throws Will log errors via LogController if account parsing fails
+ */
 export function useAccount() {
   useAppKit(); // Use the hook for checks
 
@@ -15,18 +74,25 @@ export function useAccount() {
     networks
   } = useSnapshot(ConnectionsController.state);
 
-  const allAccounts = useMemo(() => {
+  const allAccounts: Account[] = useMemo(() => {
     return Array.from(connections.values()).flatMap(_connection =>
-      _connection.accounts.map(account => {
-        const [namespace, chainId, plainAddress] = account.split(':');
+      _connection.accounts
+        .map(account => {
+          const [namespace, chainId, plainAddress] = account.split(':');
+          if (!plainAddress || !namespace || !chainId) {
+            LogController.sendError('Invalid account', 'useAccount.ts', 'useAccount', { account });
 
-        return {
-          address: plainAddress,
-          namespace,
-          chainId,
-          type: _connection.type
-        };
-      })
+            return undefined;
+          }
+
+          return {
+            address: plainAddress,
+            namespace,
+            chainId,
+            type: _connection.type
+          };
+        })
+        .filter(account => account !== undefined)
     );
   }, [connections]);
 

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -75,24 +75,27 @@ export function useAccount() {
   } = useSnapshot(ConnectionsController.state);
 
   const allAccounts: Account[] = useMemo(() => {
-    return Array.from(connections.values()).flatMap(_connection =>
-      _connection.accounts
-        .map(account => {
-          const [namespace, chainId, plainAddress] = account.split(':');
-          if (!plainAddress || !namespace || !chainId) {
-            LogController.sendError('Invalid account', 'useAccount.ts', 'useAccount', { account });
+    return Array.from(connections.values()).flatMap(
+      _connection =>
+        _connection.accounts
+          .map(account => {
+            const [namespace, chainId, plainAddress] = account.split(':');
+            if (!plainAddress || !namespace || !chainId) {
+              LogController.sendError('Invalid account', 'useAccount.ts', 'useAccount', {
+                account
+              });
 
-            return undefined;
-          }
+              return undefined;
+            }
 
-          return {
-            address: plainAddress,
-            namespace,
-            chainId,
-            type: _connection.type
-          };
-        })
-        .filter(account => account !== undefined)
+            return {
+              address: plainAddress,
+              namespace,
+              chainId,
+              type: _connection.type
+            };
+          })
+          .filter(account => account !== undefined) as Account[]
     );
   }, [connections]);
 

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -1,7 +1,7 @@
 /* eslint-disable valtio/state-snapshot-rule */
+import { ConnectionsController, CoreHelperUtil } from '@reown/appkit-core-react-native';
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
-import { ConnectionsController, CoreHelperUtil } from '@reown/appkit-core-react-native';
 import { useAppKit } from './useAppKit';
 
 export function useAccount() {
@@ -11,8 +11,24 @@ export function useAccount() {
     activeAddress: address,
     activeNamespace,
     connection,
+    connections,
     networks
   } = useSnapshot(ConnectionsController.state);
+
+  const allAccounts = useMemo(() => {
+    return Array.from(connections.values()).flatMap(_connection =>
+      _connection.accounts.map(account => {
+        const [namespace, chainId, plainAddress] = account.split(':');
+
+        return {
+          address: plainAddress,
+          namespace,
+          chainId,
+          type: _connection.type
+        };
+      })
+    );
+  }, [connections]);
 
   const activeChain = useMemo(
     () =>
@@ -23,6 +39,7 @@ export function useAccount() {
   );
 
   return {
+    allAccounts,
     address: CoreHelperUtil.getPlainAddress(address),
     isConnected: !!address,
     chainId: activeChain?.id,

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -111,7 +111,7 @@ export function useAccount() {
     allAccounts,
     address: CoreHelperUtil.getPlainAddress(address),
     isConnected: !!address,
-    chainId: String(activeChain?.id),
+    chainId: activeChain?.id !== undefined ? String(activeChain.id) : undefined,
     chain: activeChain as AppKitNetwork | undefined,
     namespace: activeNamespace
   };

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -31,7 +31,7 @@ export type { AppKitConfig } from './types';
 /****** Hooks *******/
 export { useAppKit } from './hooks/useAppKit';
 export { useProvider } from './hooks/useProvider';
-export { useAccount } from './hooks/useAccount';
+export { useAccount, type Account as UseAccountReturn } from './hooks/useAccount';
 export { useWalletInfo } from './hooks/useWalletInfo';
 export { useAppKitEvents, useAppKitEventSubscription } from './hooks/useAppKitEvents';
 export { useAppKitState } from './hooks/useAppKitState';

--- a/packages/common/src/types/blockchain/network.ts
+++ b/packages/common/src/types/blockchain/network.ts
@@ -1,6 +1,6 @@
 import type { ChainNamespace, CaipNetworkId } from '../common';
 
-export type Network = {
+export type BaseNetwork = {
   // Core viem/chain properties
   id: number | string;
   name: string;
@@ -22,7 +22,7 @@ export type Network = {
   imageUrl?: string;
 };
 
-export type AppKitNetwork = Network & {
+export type AppKitNetwork = BaseNetwork & {
   chainNamespace: ChainNamespace; // mandatory for AppKitNetwork
   caipNetworkId: CaipNetworkId; // mandatory for AppKitNetwork
 };

--- a/packages/common/src/types/blockchain/network.ts
+++ b/packages/common/src/types/blockchain/network.ts
@@ -1,6 +1,6 @@
 import type { ChainNamespace, CaipNetworkId } from '../common';
 
-export type BaseNetwork = {
+export type Network = {
   // Core viem/chain properties
   id: number | string;
   name: string;
@@ -22,7 +22,7 @@ export type BaseNetwork = {
   imageUrl?: string;
 };
 
-export type AppKitNetwork = BaseNetwork & {
+export type AppKitNetwork = Network & {
   chainNamespace: ChainNamespace; // mandatory for AppKitNetwork
   caipNetworkId: CaipNetworkId; // mandatory for AppKitNetwork
 };


### PR DESCRIPTION
**Enhancement to the `useAccount` hook:**

- The `useAccount` hook in `packages/appkit/src/hooks/useAccount.ts` now exposes an `allAccounts` property, which provides a flattened list of all accounts from the current connections, including their addresses, namespaces, chain IDs, and types. [[1]](diffhunk://#diff-5e28fa50392758d6ea9f962289511e92caf24dcbf4aa27590cfd202224da1838R14-R32) [[2]](diffhunk://#diff-5e28fa50392758d6ea9f962289511e92caf24dcbf4aa27590cfd202224da1838R42)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose all connected accounts via useAccount (with typed Account), normalize chain types, and re-export types; add changeset for patch releases.
> 
> - **Hooks (`packages/appkit/src/hooks/useAccount.ts`)**:
>   - Add `Account` interface and expose `allAccounts` aggregated from all connections (parsed from CAIP-10; logs invalid entries).
>   - Normalize return types: `chainId` now string; `chain` typed as `AppKitNetwork`.
> - **Public API (`packages/appkit/src/index.ts`)**:
>   - Re-export `useAccount` and `type Account as UseAccountReturn`.
> - **Release**:
>   - Add changeset with patch bumps across related React Native packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5366d1681af2d4d482f8bb4073683394150ff89f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->