### PR TITLE
chore: changed branch name in cicd action

### DIFF
--- a/.github/workflows/expo-ci-cd.yml
+++ b/.github/workflows/expo-ci-cd.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   push:
-    branches: [main, development]
+    branches: [main, develop]
     paths-ignore:
       - "**.md"
       - "examples/**"
@@ -21,7 +21,7 @@ on:
       - ".maestro/**"
   pull_request:
     types: [opened]
-    branches: [main, development]
+    branches: [main, develop]
   workflow_dispatch:
     inputs:
       platform:


### PR DESCRIPTION
This pull request makes a minor update to the CI/CD workflow configuration to ensure that GitHub Actions trigger on the correct branches. Specifically, it changes the workflow triggers from the `development` branch to the `develop` branch.

- Workflow trigger updates:
  * [`.github/workflows/expo-ci-cd.yml`](diffhunk://#diff-ea9c9549713f790f3632562f314ae9642f634d8dcad9d0626872ecdffaf755cfL9-R9): Updated the `push` and `pull_request` triggers to use the `develop` branch instead of `development`. [[1]](diffhunk://#diff-ea9c9549713f790f3632562f314ae9642f634d8dcad9d0626872ecdffaf755cfL9-R9) [[2]](diffhunk://#diff-ea9c9549713f790f3632562f314ae9642f634d8dcad9d0626872ecdffaf755cfL24-R24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions workflow to trigger on the develop branch (instead of development) for push and pull_request events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f65a9542c13c0e1fdfeab7d5a3b08d0536036164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->