### PR TITLE
feat: updated the switchNetwork to accept a CAIP network ID string

### DIFF
--- a/.changeset/spotty-pigs-read.md
+++ b/.changeset/spotty-pigs-read.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+chore: updated the switchNetwork to accept a CAIP network ID string

--- a/apps/native/App.tsx
+++ b/apps/native/App.tsx
@@ -18,7 +18,7 @@ import {
   bitcoin
 } from '@reown/appkit-react-native';
 
-import { Button, Text } from '@reown/appkit-ui-react-native';
+import { Text } from '@reown/appkit-ui-react-native';
 
 import { chains } from './src/utils/WagmiUtils';
 import { OpenButton } from './src/components/OpenButton';

--- a/apps/native/App.tsx
+++ b/apps/native/App.tsx
@@ -112,9 +112,6 @@ export default function Native() {
               <ActionsView />
               <OpenButton />
               <DisconnectButton />
-              <Button size="sm" onPress={() => appKit.disconnect()}>
-                Disconnect
-              </Button>
               <EventsView style={styles.events} />
               <AppKit />
             </SafeAreaView>

--- a/apps/native/src/components/OpenButton.tsx
+++ b/apps/native/src/components/OpenButton.tsx
@@ -8,7 +8,7 @@ export function OpenButton() {
 
   return !isConnected ? (
     <Button testID="open-hook-button" style={styles.button} onPress={() => open()}>
-      Open hook
+      Open AppKit
     </Button>
   ) : null;
 }

--- a/apps/native/src/views/ActionsView.tsx
+++ b/apps/native/src/views/ActionsView.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
-import { FlexView } from '@reown/appkit-ui-react-native';
-import { useAccount } from '@reown/appkit-react-native';
+import { Button, FlexView } from '@reown/appkit-ui-react-native';
+import { useAccount, useAppKit, useAppKitState } from '@reown/appkit-react-native';
 
 // import { EthersActionsView } from './EthersActionsView';
 import { SolanaActionsView } from './SolanaActionsView';
@@ -8,7 +8,8 @@ import { BitcoinActionsView } from './BitcoinActionsView';
 import { WagmiActionsView } from './WagmiActionsView';
 
 export function ActionsView() {
-  const isConnected = true;
+  const { switchNetwork, disconnect } = useAppKit();
+  const { isConnected } = useAppKitState();
   const { namespace } = useAccount();
 
   return isConnected ? (
@@ -20,6 +21,8 @@ export function ActionsView() {
       ) : namespace === 'bip122' ? (
         <BitcoinActionsView />
       ) : null}
+      <Button onPress={() => switchNetwork('eip155:1')}>Switch to mainnet</Button>
+      <Button onPress={() => disconnect()}>Disconnect</Button>
     </FlexView>
   ) : null;
 }

--- a/apps/native/tests/shared/pages/OnRampPage.ts
+++ b/apps/native/tests/shared/pages/OnRampPage.ts
@@ -72,9 +72,8 @@ export class OnRampPage {
   }
 
   async clickContinue() {
-    const continueButton = this.page.getByTestId('button-continue');
+    const continueButton = this.page.getByTestId('button-continue-enabled');
     await expect(continueButton).toBeVisible({ timeout: 5000 });
-    await expect(continueButton).toBeEnabled({ timeout: 5000 });
     await continueButton.click();
     // Wait for navigation
     await this.page.waitForTimeout(TIMEOUTS.ANIMATION);

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   ],
   "scripts": {
     "gallery": "turbo run dev:gallery",
+    "start": "cd apps/native && yarn start",
     "android": "cd apps/native && yarn android",
     "ios": "cd apps/native && yarn ios",
     "web": "cd apps/native && yarn web",
+    "watchman:clean": "watchman shutdown-server && watchman watch-del-all",
     "build": "turbo build",
     "build:gallery": "turbo run build:gallery",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -271,29 +271,41 @@ export class AppKit {
     return this.networks;
   }
 
-  async switchNetwork(network: AppKitNetwork): Promise<void> {
+  async switchNetwork(network: AppKitNetwork | CaipNetworkId): Promise<void> {
     const { isConnected } = ConnectionsController.state;
 
+    const appKitNetwork =
+      typeof network === 'string' ? this.networks.find(n => n.caipNetworkId === network) : network;
+
+    if (!appKitNetwork) {
+      LogController.sendError(`Network not found: ${network}`, 'AppKit.ts', 'switchNetwork');
+
+      return;
+    }
+
     if (!isConnected) {
-      OptionsController.setDefaultNetwork(network);
+      OptionsController.setDefaultNetwork(appKitNetwork);
 
       return Promise.resolve();
     }
 
-    const adapter = this.getAdapterByNamespace(network.chainNamespace);
+    const adapter = this.getAdapterByNamespace(appKitNetwork.chainNamespace);
     if (!adapter) throw new Error('No active adapter');
 
-    await adapter.switchNetwork(network);
+    await adapter.switchNetwork(appKitNetwork);
 
     EventsController.sendEvent({
       type: 'track',
       event: 'SWITCH_NETWORK',
       properties: {
-        network: network.caipNetworkId
+        network: appKitNetwork.caipNetworkId
       }
     });
 
-    ConnectionsController.setActiveNetwork(network.chainNamespace, network.caipNetworkId);
+    ConnectionsController.setActiveNetwork(
+      appKitNetwork.chainNamespace,
+      appKitNetwork.caipNetworkId
+    );
   }
 
   open(options?: AppKitOpenOptions) {

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -271,6 +271,13 @@ export class AppKit {
     return this.networks;
   }
 
+  /**
+   * Switches to a different network.
+   * @param network - Either an AppKitNetwork object or a CAIP network ID string (e.g., 'eip155:1')
+   * @throws {Error} When the network is not found in configured networks
+   * @throws {Error} When no active adapter is available (only when connected)
+   * @returns Promise that resolves when the network switch is complete
+   */
   async switchNetwork(network: AppKitNetwork | CaipNetworkId): Promise<void> {
     const { isConnected } = ConnectionsController.state;
 
@@ -278,15 +285,16 @@ export class AppKit {
       typeof network === 'string' ? this.networks.find(n => n.caipNetworkId === network) : network;
 
     if (!appKitNetwork) {
+      const error = new Error(`Network not found: ${network}`);
       LogController.sendError(`Network not found: ${network}`, 'AppKit.ts', 'switchNetwork');
 
-      return;
+      throw error;
     }
 
     if (!isConnected) {
       OptionsController.setDefaultNetwork(appKitNetwork);
 
-      return Promise.resolve();
+      return;
     }
 
     const adapter = this.getAdapterByNamespace(appKitNetwork.chainNamespace);


### PR DESCRIPTION
**UI and Logic Refactoring:**
* Updated the `switchNetwork` method in `AppKit` to accept either a network object or a CAIP network ID string, improving its flexibility and error handling.

**Testing Improvements:**

* Updated the test selector for the continue button in the on-ramp page to use a more specific test ID, improving test reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend `switchNetwork` to accept CAIP IDs and update native UI/actions, tests, and scripts accordingly.
> 
> - **Core (`packages/appkit/src/AppKit.ts`)**:
>   - Enhance `switchNetwork` to accept `AppKitNetwork` or CAIP ID string (e.g., `eip155:1`), with validation and improved error handling; update event and active network handling.
> - **Native App**:
>   - `apps/native/src/views/ActionsView.tsx`: Use `useAppKit`/`useAppKitState`; add buttons to `switchNetwork('eip155:1')` and `disconnect`.
>   - `apps/native/src/components/OpenButton.tsx`: Rename button label to "Open AppKit".
>   - `apps/native/App.tsx`: Remove unused `Button` import and inline disconnect button.
> - **Tests**:
>   - `apps/native/tests/shared/pages/OnRampPage.ts`: Target `button-continue-enabled` test ID and remove enabled assertion before clicking.
> - **Tooling**:
>   - `package.json`: Add `start` and `watchman:clean` scripts.
> - **Changeset**:
>   - Patch bumps for React Native packages noting the `switchNetwork` CAIP support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad3a7a4807f944a433bc691ea6979d276678094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->