### PR TITLE
fix: return empty array if not connected

### DIFF
--- a/.changeset/yellow-streets-call.md
+++ b/.changeset/yellow-streets-call.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+fix: useAccount hook now returns empty array if appkit is not connected

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -75,6 +75,8 @@ export function useAccount() {
   } = useSnapshot(ConnectionsController.state);
 
   const allAccounts: Account[] = useMemo(() => {
+    if (!address) return [];
+
     return Array.from(connections.values()).flatMap(
       _connection =>
         _connection.accounts
@@ -97,7 +99,7 @@ export function useAccount() {
           })
           .filter(account => account !== undefined) as Account[]
     );
-  }, [connections]);
+  }, [connections, address]);
 
   const activeChain = useMemo(
     () =>


### PR DESCRIPTION
This pull request makes a small improvement to the `useAccount` hook to ensure that the list of accounts is only computed when an `address` is present, and updates the hook's dependencies for correctness.

* Added a guard clause to return an empty array if `address` is not defined, preventing unnecessary computation.
* Updated the dependency array of the `useMemo` hook to include `address`, ensuring the memoized value updates correctly when `address` changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `useAccount` now returns `[]` when no address is active and updates memo deps; patch releases prepared across React Native packages.
> 
> - **Hooks**
>   - `packages/appkit/src/hooks/useAccount.ts`:
>     - Guard: return `[]` from `allAccounts` when `address` is falsy.
>     - Update `useMemo` deps to `[connections, address]`.
> - **Release**
>   - Changeset adds patch bumps for multiple `@reown/*-react-native` packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd620bda62118fc0da0b85971c6ed80c9d084592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->