### PR TITLE
chore: Added new useAppKitTheme hook

### DIFF
--- a/.changeset/spotty-foxes-fry.md
+++ b/.changeset/spotty-foxes-fry.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+chore: added useAppKitTheme hook

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:gallery": "turbo run build:gallery",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prettier": "prettier --check .",
-    "test": "turbo build && turbo run test --parallel",
+    "test": "turbo run test --parallel",
     "clean": "turbo clean && rm -rf node_modules && (watchman watch-del-all || true)",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .gitignore",
     "playwright:test": "cd apps/native && yarn playwright:test",

--- a/packages/appkit/babel.config.js
+++ b/packages/appkit/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset']
+};

--- a/packages/appkit/jest-setup.ts
+++ b/packages/appkit/jest-setup.ts
@@ -1,0 +1,2 @@
+// Import shared setup
+import '@shared-jest-setup';

--- a/packages/appkit/jest.config.ts
+++ b/packages/appkit/jest.config.ts
@@ -1,0 +1,9 @@
+const appkitConfig = {
+  ...require('../../jest.config'),
+  setupFilesAfterEnv: ['./jest-setup.ts'],
+  // Override the moduleNameMapper to use the correct path from the package
+  moduleNameMapper: {
+    '^@shared-jest-setup$': '../../jest-shared-setup.ts'
+  }
+};
+module.exports = appkitConfig;

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "bob build",
     "clean": "rm -rf lib",
+    "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "files": [

--- a/packages/appkit/src/AppKitContext.tsx
+++ b/packages/appkit/src/AppKitContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { AppKit } from './AppKit';
 
-interface AppKitContextType {
+export interface AppKitContextType {
   appKit: AppKit | null;
 }
 

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -36,7 +36,7 @@ describe('useAppKitTheme', () => {
     // Reset ThemeController state
     ThemeController.state = {
       themeMode: undefined,
-      themeVariables: {}
+      themeVariables: undefined
     };
   });
 
@@ -55,13 +55,13 @@ describe('useAppKitTheme', () => {
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
 
     expect(result.current.themeMode).toBeUndefined();
-    expect(result.current.themeVariables).toEqual({});
+    expect(result.current.themeVariables).toBeUndefined();
   });
 
   it('should return dark theme mode when set', () => {
     ThemeController.state = {
       themeMode: 'dark',
-      themeVariables: {}
+      themeVariables: undefined
     };
 
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
@@ -72,7 +72,7 @@ describe('useAppKitTheme', () => {
   it('should return light theme mode when set', () => {
     ThemeController.state = {
       themeMode: 'light',
-      themeVariables: {}
+      themeVariables: undefined
     };
 
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@reown/appkit-core-react-native', () => ({
   ThemeController: {
     state: {
       themeMode: undefined,
-      themeVariables: {}
+      themeVariables: undefined
     },
     setThemeMode: jest.fn(),
     setThemeVariables: jest.fn()

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -5,6 +5,13 @@ import { ThemeController } from '@reown/appkit-core-react-native';
 import { type AppKitContextType, AppKitContext } from '../../AppKitContext';
 import type { AppKit } from '../../AppKit';
 
+// Mock Appearance
+jest.mock('react-native', () => ({
+  Appearance: {
+    getColorScheme: jest.fn().mockReturnValue('light')
+  }
+}));
+
 // Mock valtio
 jest.mock('valtio', () => ({
   useSnapshot: jest.fn(state => state)
@@ -14,7 +21,7 @@ jest.mock('valtio', () => ({
 jest.mock('@reown/appkit-core-react-native', () => ({
   ThemeController: {
     state: {
-      themeMode: 'dark',
+      themeMode: undefined,
       themeVariables: {}
     },
     setThemeMode: jest.fn(),
@@ -35,7 +42,7 @@ describe('useAppKitTheme', () => {
     jest.clearAllMocks();
     // Reset ThemeController state
     ThemeController.state = {
-      themeMode: 'dark',
+      themeMode: undefined,
       themeVariables: {}
     };
   });
@@ -55,7 +62,7 @@ describe('useAppKitTheme', () => {
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
 
     expect(result.current.themeMode).toBeUndefined();
-    expect(result.current.themeVariables).toBe({});
+    expect(result.current.themeVariables).toStrictEqual({});
   });
 
   it('should return dark theme mode when set', () => {

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -14,8 +14,8 @@ jest.mock('valtio', () => ({
 jest.mock('@reown/appkit-core-react-native', () => ({
   ThemeController: {
     state: {
-      themeMode: undefined,
-      themeVariables: undefined
+      themeMode: 'dark',
+      themeVariables: {}
     },
     setThemeMode: jest.fn(),
     setThemeVariables: jest.fn()
@@ -35,8 +35,8 @@ describe('useAppKitTheme', () => {
     jest.clearAllMocks();
     // Reset ThemeController state
     ThemeController.state = {
-      themeMode: undefined,
-      themeVariables: undefined
+      themeMode: 'dark',
+      themeVariables: {}
     };
   });
 
@@ -55,13 +55,13 @@ describe('useAppKitTheme', () => {
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
 
     expect(result.current.themeMode).toBeUndefined();
-    expect(result.current.themeVariables).toBeUndefined();
+    expect(result.current.themeVariables).toBe({});
   });
 
   it('should return dark theme mode when set', () => {
     ThemeController.state = {
       themeMode: 'dark',
-      themeVariables: undefined
+      themeVariables: {}
     };
 
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
@@ -72,7 +72,7 @@ describe('useAppKitTheme', () => {
   it('should return light theme mode when set', () => {
     ThemeController.state = {
       themeMode: 'light',
-      themeVariables: undefined
+      themeVariables: {}
     };
 
     const { result } = renderHook(() => useAppKitTheme(), { wrapper });
@@ -83,7 +83,7 @@ describe('useAppKitTheme', () => {
   it('should return theme variables when set', () => {
     const themeVariables = { accent: '#00BB7F' };
     ThemeController.state = {
-      themeMode: undefined,
+      themeMode: 'dark',
       themeVariables
     };
 

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -1,0 +1,188 @@
+import { renderHook, act } from '@testing-library/react-native';
+import React from 'react';
+import { useAppKitTheme } from '../../hooks/useAppKitTheme';
+import { ThemeController } from '@reown/appkit-core-react-native';
+import { type AppKitContextType, AppKitContext } from '../../AppKitContext';
+import type { AppKit } from '../../AppKit';
+
+// Mock valtio
+jest.mock('valtio', () => ({
+  useSnapshot: jest.fn(state => state)
+}));
+
+// Mock ThemeController
+jest.mock('@reown/appkit-core-react-native', () => ({
+  ThemeController: {
+    state: {
+      themeMode: undefined,
+      themeVariables: {}
+    },
+    setThemeMode: jest.fn(),
+    setThemeVariables: jest.fn()
+  }
+}));
+
+describe('useAppKitTheme', () => {
+  const mockAppKit = {} as AppKit;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const contextValue: AppKitContextType = { appKit: mockAppKit };
+
+    return <AppKitContext.Provider value={contextValue}>{children}</AppKitContext.Provider>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset ThemeController state
+    ThemeController.state = {
+      themeMode: undefined,
+      themeVariables: {}
+    };
+  });
+
+  it('should throw error when used outside AppKitProvider', () => {
+    // Suppress console.error for this test
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useAppKitTheme());
+    }).toThrow('AppKit instance is not yet available in context.');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should return initial theme state', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    expect(result.current.themeMode).toBeUndefined();
+    expect(result.current.themeVariables).toEqual({});
+  });
+
+  it('should return dark theme mode when set', () => {
+    ThemeController.state = {
+      themeMode: 'dark',
+      themeVariables: {}
+    };
+
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    expect(result.current.themeMode).toBe('dark');
+  });
+
+  it('should return light theme mode when set', () => {
+    ThemeController.state = {
+      themeMode: 'light',
+      themeVariables: {}
+    };
+
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    expect(result.current.themeMode).toBe('light');
+  });
+
+  it('should return theme variables when set', () => {
+    const themeVariables = { accent: '#00BB7F' };
+    ThemeController.state = {
+      themeMode: undefined,
+      themeVariables
+    };
+
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    expect(result.current.themeVariables).toEqual(themeVariables);
+  });
+
+  it('should call ThemeController.setThemeMode when setThemeMode is called', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    act(() => {
+      result.current.setThemeMode('dark');
+    });
+
+    expect(ThemeController.setThemeMode).toHaveBeenCalledWith('dark');
+  });
+
+  it('should call ThemeController.setThemeMode with undefined', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    act(() => {
+      result.current.setThemeMode(undefined);
+    });
+
+    expect(ThemeController.setThemeMode).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should call ThemeController.setThemeVariables when setThemeVariables is called', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+    const themeVariables = { accent: '#FF5733' };
+
+    act(() => {
+      result.current.setThemeVariables(themeVariables);
+    });
+
+    expect(ThemeController.setThemeVariables).toHaveBeenCalledWith(themeVariables);
+  });
+
+  it('should call ThemeController.setThemeVariables with undefined', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    act(() => {
+      result.current.setThemeVariables(undefined);
+    });
+
+    expect(ThemeController.setThemeVariables).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should return stable function references', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    const firstSetThemeMode = result.current.setThemeMode;
+    const firstSetThemeVariables = result.current.setThemeVariables;
+
+    // Functions should be stable (same reference)
+    expect(result.current.setThemeMode).toBe(firstSetThemeMode);
+    expect(result.current.setThemeVariables).toBe(firstSetThemeVariables);
+  });
+
+  it('should update theme mode and variables together', () => {
+    ThemeController.state = {
+      themeMode: 'dark',
+      themeVariables: { accent: '#00BB7F' }
+    };
+
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    expect(result.current.themeMode).toBe('dark');
+    expect(result.current.themeVariables).toEqual({ accent: '#00BB7F' });
+  });
+
+  it('should handle multiple setThemeMode calls', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+
+    act(() => {
+      result.current.setThemeMode('dark');
+      result.current.setThemeMode('light');
+      result.current.setThemeMode(undefined);
+    });
+
+    expect(ThemeController.setThemeMode).toHaveBeenCalledTimes(3);
+    expect(ThemeController.setThemeMode).toHaveBeenNthCalledWith(1, 'dark');
+    expect(ThemeController.setThemeMode).toHaveBeenNthCalledWith(2, 'light');
+    expect(ThemeController.setThemeMode).toHaveBeenNthCalledWith(3, undefined);
+  });
+
+  it('should handle multiple setThemeVariables calls', () => {
+    const { result } = renderHook(() => useAppKitTheme(), { wrapper });
+    const variables1 = { accent: '#00BB7F' };
+    const variables2 = { accent: '#FF5733' };
+
+    act(() => {
+      result.current.setThemeVariables(variables1);
+      result.current.setThemeVariables(variables2);
+    });
+
+    expect(ThemeController.setThemeVariables).toHaveBeenCalledTimes(2);
+    expect(ThemeController.setThemeVariables).toHaveBeenNthCalledWith(1, variables1);
+    expect(ThemeController.setThemeVariables).toHaveBeenNthCalledWith(2, variables2);
+  });
+});

--- a/packages/appkit/src/hooks/useAccount.ts
+++ b/packages/appkit/src/hooks/useAccount.ts
@@ -6,8 +6,8 @@ import {
 } from '@reown/appkit-core-react-native';
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
-import { useAppKit } from './useAppKit';
 import type { AccountType, AppKitNetwork } from '@reown/appkit-common-react-native';
+import { useAppKitContext } from './useAppKitContext';
 
 /**
  * Represents a blockchain account with its associated metadata
@@ -64,7 +64,7 @@ export interface Account {
  * @throws Will log errors via LogController if account parsing fails
  */
 export function useAccount() {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
 
   const {
     activeAddress: address,

--- a/packages/appkit/src/hooks/useAppKit.ts
+++ b/packages/appkit/src/hooks/useAppKit.ts
@@ -1,27 +1,60 @@
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { ChainNamespace } from '@reown/appkit-common-react-native';
 
 import type { AppKit } from '../AppKit';
-import { AppKitContext } from '../AppKitContext';
+import { useAppKitContext } from './useAppKitContext';
 
+/**
+ * Interface representing the return value of the useAppKit hook
+ */
 interface UseAppKitReturn {
+  /** Function to open the AppKit modal with optional view configuration */
   open: AppKit['open'];
+  /** Function to close the AppKit modal */
   close: AppKit['close'];
+  /** Function to disconnect the wallet, optionally scoped to a specific namespace */
   disconnect: (namespace?: ChainNamespace) => void;
+  /** Function to switch to a different network */
   switchNetwork: AppKit['switchNetwork'];
 }
 
+/**
+ * Hook to access core AppKit functionality for controlling the modal
+ *
+ * @remarks
+ * This hook provides access to the main AppKit instance methods for opening/closing
+ * the modal, disconnecting wallets, and switching networks. All functions are memoized
+ * and properly bound to ensure stable references across renders.
+ *
+ * @returns {UseAppKitReturn} An object containing:
+ *   - `open`: Opens the AppKit modal, optionally with a specific view
+ *   - `close`: Closes the AppKit modal
+ *   - `disconnect`: Disconnects the current wallet connection (optionally for a specific namespace)
+ *   - `switchNetwork`: Switches to a different blockchain network
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ * @throws {Error} If AppKit instance is not available in context
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { open, close, disconnect, switchNetwork } = useAppKit();
+ *
+ *   return (
+ *     <View>
+ *       <Button onPress={() => open()} title="Connect Wallet" />
+ *       <Button onPress={() => disconnect()} title="Disconnect" />
+ *       <Button
+ *         onPress={() => switchNetwork('eip155:1')}
+ *         title="Switch to Ethereum"
+ *       />
+ *     </View>
+ *   );
+ * }
+ * ```
+ */
 export const useAppKit = (): UseAppKitReturn => {
-  const context = useContext(AppKitContext);
-
-  if (context === undefined) {
-    throw new Error('useAppKit must be used within an AppKitProvider');
-  }
-
-  if (!context.appKit) {
-    // This might happen if the provider is rendered before AppKit is initialized
-    throw new Error('AppKit instance is not yet available in context.');
-  }
+  const context = useAppKitContext();
 
   const stableFunctions = useMemo(() => {
     if (!context.appKit) {

--- a/packages/appkit/src/hooks/useAppKitContext.ts
+++ b/packages/appkit/src/hooks/useAppKitContext.ts
@@ -1,0 +1,43 @@
+import { useContext } from 'react';
+
+import { AppKitContext, type AppKitContextType } from '../AppKitContext';
+
+/**
+ * Hook to access the AppKit context
+ *
+ * @remarks
+ * This is an internal hook used by other AppKit hooks to ensure they're used within
+ * the AppKitProvider. You typically don't need to use this hook directly - use the
+ * higher-level hooks like `useAppKit`, `useAccount`, `useAppKitTheme`, etc. instead.
+ *
+ * @returns {AppKitContextType} The AppKit context containing the AppKit instance
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ * @throws {Error} If the AppKit instance is not yet available in context
+ *
+ * @internal
+ *
+ * @example
+ * ```tsx
+ * // This is typically used internally by other hooks
+ * function MyCustomHook() {
+ *   const context = useAppKitContext();
+ *   // Use context.appKit...
+ * }
+ * ```
+ */
+
+export const useAppKitContext = (): AppKitContextType => {
+  const context = useContext(AppKitContext);
+
+  if (context === undefined) {
+    throw new Error('useAppKit must be used within an AppKitProvider');
+  }
+
+  if (!context.appKit) {
+    // This might happen if the provider is rendered before AppKit is initialized
+    throw new Error('AppKit instance is not yet available in context.');
+  }
+
+  return context;
+};

--- a/packages/appkit/src/hooks/useAppKitContext.ts
+++ b/packages/appkit/src/hooks/useAppKitContext.ts
@@ -31,7 +31,7 @@ export const useAppKitContext = (): AppKitContextType => {
   const context = useContext(AppKitContext);
 
   if (context === undefined) {
-    throw new Error('useAppKit must be used within an AppKitProvider');
+    throw new Error('useAppKitContext must be used within an AppKitProvider');
   }
 
   if (!context.appKit) {

--- a/packages/appkit/src/hooks/useAppKitEvents.ts
+++ b/packages/appkit/src/hooks/useAppKitEvents.ts
@@ -2,10 +2,42 @@ import { useEffect } from 'react';
 import { useSnapshot } from 'valtio';
 import { EventsController, type EventsControllerState } from '@reown/appkit-core-react-native';
 import { type EventName } from '@reown/appkit-common-react-native';
-import { useAppKit } from './useAppKit';
+import { useAppKitContext } from './useAppKitContext';
 
+/**
+ * Hook to subscribe to all AppKit events
+ *
+ * @remarks
+ * This hook provides reactive access to AppKit's event system, allowing you to
+ * monitor all events that occur within the AppKit lifecycle (connections, disconnections,
+ * network changes, etc.). The callback is invoked whenever a new event is emitted.
+ *
+ * @param callback - Optional callback function invoked when any event occurs
+ *
+ * @returns An object containing:
+ *   - `data`: The most recent event data
+ *   - `timestamp`: The timestamp of the most recent event
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { data, timestamp } = useAppKitEvents((event) => {
+ *     console.log('Event occurred:', event.data.event);
+ *   });
+ *
+ *   return (
+ *     <View>
+ *       <Text>Last event: {data?.event}</Text>
+ *       <Text>Time: {timestamp}</Text>
+ *     </View>
+ *   );
+ * }
+ * ```
+ */
 export function useAppKitEvents(callback?: (newEvent: EventsControllerState) => void) {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
   const { data, timestamp } = useSnapshot(EventsController.state);
 
   useEffect(() => {
@@ -21,11 +53,39 @@ export function useAppKitEvents(callback?: (newEvent: EventsControllerState) => 
   return { data, timestamp };
 }
 
+/**
+ * Hook to subscribe to a specific AppKit event
+ *
+ * @remarks
+ * This hook allows you to listen for a specific event type rather than all events.
+ * It's more efficient than `useAppKitEvents` when you only care about a particular event.
+ *
+ * @param event - The specific event name to subscribe to (e.g., 'MODAL_OPEN', 'CONNECT_SUCCESS')
+ * @param callback - Callback function invoked when the specified event occurs
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   useAppKitEventSubscription('CONNECT_SUCCESS', (event) => {
+ *     console.log('Wallet connected!', event.data);
+ *   });
+ *
+ *   useAppKitEventSubscription('DISCONNECT_SUCCESS', (event) => {
+ *     console.log('Wallet disconnected!', event.data);
+ *   });
+ *
+ *   return <View>{/ Your component /}</View>;
+ * }
+ * ```
+ */
+
 export function useAppKitEventSubscription(
   event: EventName,
   callback: (newEvent: EventsControllerState) => void
 ) {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
 
   useEffect(() => {
     const unsubscribe = EventsController?.subscribeEvent(event, callback);

--- a/packages/appkit/src/hooks/useAppKitLogs.ts
+++ b/packages/appkit/src/hooks/useAppKitLogs.ts
@@ -1,7 +1,7 @@
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { LogController, type LogEntry, type LogLevel } from '@reown/appkit-core-react-native';
-import { AppKitContext } from '../AppKitContext';
+import { useAppKitContext } from './useAppKitContext';
 
 export interface UseAppKitLogsReturn {
   /**
@@ -65,15 +65,7 @@ export interface UseAppKitLogsReturn {
  * ```
  */
 export const useAppKitLogs = (): UseAppKitLogsReturn => {
-  const context = useContext(AppKitContext);
-
-  if (context === undefined) {
-    throw new Error('useAppKitLogs must be used within an AppKitProvider');
-  }
-
-  if (!context.appKit) {
-    throw new Error('AppKit instance is not yet available in context.');
-  }
+  useAppKitContext();
 
   const { logs } = useSnapshot(LogController.state);
 

--- a/packages/appkit/src/hooks/useAppKitState.ts
+++ b/packages/appkit/src/hooks/useAppKitState.ts
@@ -2,10 +2,43 @@
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController, ModalController } from '@reown/appkit-core-react-native';
-import { useAppKit } from './useAppKit';
+import { useAppKitContext } from './useAppKitContext';
+
+/**
+ * Hook to access the overall state of the AppKit modal and connection
+ *
+ * @remarks
+ * This hook provides a high-level view of the AppKit's current state, including
+ * whether the modal is open, if it's loading, connection status, and the active chain.
+ * It's useful for coordinating UI elements with the AppKit's state.
+ *
+ * @returns An object containing:
+ *   - `isOpen`: Whether the AppKit modal is currently open
+ *   - `isLoading`: Whether the AppKit is in a loading state
+ *   - `isConnected`: Whether a wallet is currently connected
+ *   - `chain`: The currently active blockchain network
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { isOpen, isLoading, isConnected, chain } = useAppKitState();
+ *
+ *   return (
+ *     <View>
+ *       <Text>Modal: {isOpen ? 'Open' : 'Closed'}</Text>
+ *       <Text>Loading: {isLoading ? 'Yes' : 'No'}</Text>
+ *       <Text>Connected: {isConnected ? 'Yes' : 'No'}</Text>
+ *       {chain && <Text>Chain: {chain.name}</Text>}
+ *     </View>
+ *   );
+ * }
+ * ```
+ */
 
 export function useAppKitState() {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
   const { activeAddress: address, connection, networks } = useSnapshot(ConnectionsController.state);
   const { open, loading } = useSnapshot(ModalController.state);
 

--- a/packages/appkit/src/hooks/useAppKitTheme.ts
+++ b/packages/appkit/src/hooks/useAppKitTheme.ts
@@ -7,7 +7,7 @@ import { useAppKit } from './useAppKit';
 /**
  * Interface representing the result of the useAppKitTheme hook
  */
-interface UseAppKitThemeReturn {
+export interface UseAppKitThemeReturn {
   /** The current theme mode ('dark' or 'light'), or undefined if using system default */
   themeMode: ThemeMode | undefined;
   /** The current theme variables, currently only supports 'accent' color */

--- a/packages/appkit/src/hooks/useAppKitTheme.ts
+++ b/packages/appkit/src/hooks/useAppKitTheme.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { useSnapshot } from 'valtio';
+import type { ThemeMode, ThemeVariables } from '@reown/appkit-common-react-native';
+import { ThemeController } from '@reown/appkit-core-react-native';
+import { useAppKit } from './useAppKit';
+
+/**
+ * Interface representing the result of the useAppKitTheme hook
+ */
+interface UseAppKitThemeReturn {
+  /** The current theme mode ('dark' or 'light'), or undefined if using system default */
+  themeMode: ThemeMode | undefined;
+  /** The current theme variables, currently only supports 'accent' color */
+  themeVariables: ThemeVariables | undefined;
+  /** Function to set the theme mode */
+  setThemeMode: (themeMode: ThemeMode | undefined) => void;
+  /** Function to set theme variables */
+  setThemeVariables: (themeVariables: ThemeVariables | undefined) => void;
+}
+
+/**
+ * Hook to control the visual appearance of the AppKit modal
+ *
+ * @remarks
+ * This hook provides access to the theme mode and theme variables, allowing you to
+ * customize the modal's appearance. Use this hook when you need to implement dark/light
+ * mode or match the modal's appearance with your application's theme.
+ *
+ * Currently, the only supported theme variable is `accent`, which controls the primary
+ * accent color used throughout the modal interface.
+ *
+ * @returns {UseAppKitThemeReturn} An object containing:
+ *   - `themeMode`: The current theme mode ('dark' or 'light')
+ *   - `themeVariables`: The current theme variables (only 'accent' is supported)
+ *   - `setThemeMode`: Function to change the theme mode
+ *   - `setThemeVariables`: Function to update theme variables
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ *
+ * @example
+ * ```typescript
+ * import { useAppKitTheme } from '@reown/appkit-react-native';
+ *
+ * function MyComponent() {
+ *   const { themeMode, themeVariables, setThemeMode, setThemeVariables } = useAppKitTheme();
+ *
+ *   // Set theme to dark mode
+ *   setThemeMode('dark');
+ *
+ *   // Customize the accent color
+ *   setThemeVariables({
+ *     accent: '#00BB7F'
+ *   });
+ *
+ *   return (
+ *     <View>
+ *       <Text>Current theme: {themeMode}</Text>
+ *       <Text>Accent color: {themeVariables?.accent}</Text>
+ *     </View>
+ *   );
+ * }
+ * ```
+ */
+export function useAppKitTheme(): UseAppKitThemeReturn {
+  useAppKit(); // Use the hook for checks
+  const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
+
+  const stableFunctions = useMemo(
+    () => ({
+      setThemeMode: ThemeController.setThemeMode.bind(ThemeController),
+      setThemeVariables: ThemeController.setThemeVariables.bind(ThemeController)
+    }),
+    []
+  );
+
+  return {
+    themeMode,
+    themeVariables,
+    ...stableFunctions
+  };
+}

--- a/packages/appkit/src/hooks/useAppKitTheme.ts
+++ b/packages/appkit/src/hooks/useAppKitTheme.ts
@@ -9,9 +9,9 @@ import { useAppKitContext } from './useAppKitContext';
  */
 export interface UseAppKitThemeReturn {
   /** The current theme mode ('dark' or 'light'), or undefined if using system default */
-  themeMode: ThemeMode | undefined;
+  themeMode: ThemeMode;
   /** The current theme variables, currently only supports 'accent' color */
-  themeVariables: ThemeVariables | undefined;
+  themeVariables: ThemeVariables;
   /** Function to set the theme mode */
   setThemeMode: (themeMode: ThemeMode | undefined) => void;
   /** Function to set theme variables */

--- a/packages/appkit/src/hooks/useAppKitTheme.ts
+++ b/packages/appkit/src/hooks/useAppKitTheme.ts
@@ -9,7 +9,7 @@ import { useAppKitContext } from './useAppKitContext';
  */
 export interface UseAppKitThemeReturn {
   /** The current theme mode ('dark' or 'light'), or undefined if using system default */
-  themeMode: ThemeMode;
+  themeMode?: ThemeMode;
   /** The current theme variables, currently only supports 'accent' color */
   themeVariables: ThemeVariables;
   /** Function to set the theme mode */

--- a/packages/appkit/src/hooks/useAppKitTheme.ts
+++ b/packages/appkit/src/hooks/useAppKitTheme.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import type { ThemeMode, ThemeVariables } from '@reown/appkit-common-react-native';
 import { ThemeController } from '@reown/appkit-core-react-native';
-import { useAppKit } from './useAppKit';
+import { useAppKitContext } from './useAppKitContext';
 
 /**
  * Interface representing the result of the useAppKitTheme hook
@@ -62,7 +62,7 @@ export interface UseAppKitThemeReturn {
  * ```
  */
 export function useAppKitTheme(): UseAppKitThemeReturn {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
   const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
 
   const stableFunctions = useMemo(

--- a/packages/appkit/src/hooks/useProvider.ts
+++ b/packages/appkit/src/hooks/useProvider.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController, LogController } from '@reown/appkit-core-react-native';
 import type { Provider, ChainNamespace } from '@reown/appkit-common-react-native';
+import { useAppKitContext } from './useAppKitContext';
 
 /**
  * Interface representing the result of the useProvider hook
@@ -29,14 +30,12 @@ interface ProviderResult {
  *
  * if (provider) {
  *   // Use the provider for blockchain operations
- *   const balance = await provider.request({
- *     method: 'eth_getBalance',
- *     params: [address, 'latest']
- *   });
+ *   const balance = await provider.request({...});
  * }
  * ```
  */
 export function useProvider(): ProviderResult {
+  useAppKitContext();
   const { connection } = useSnapshot(ConnectionsController.state);
 
   const returnValue = useMemo(() => {

--- a/packages/appkit/src/hooks/useWalletInfo.ts
+++ b/packages/appkit/src/hooks/useWalletInfo.ts
@@ -1,10 +1,41 @@
 import { useMemo } from 'react';
 import { useSnapshot } from 'valtio';
 import { ConnectionsController } from '@reown/appkit-core-react-native';
-import { useAppKit } from './useAppKit';
+import { useAppKitContext } from './useAppKitContext';
 
+/**
+ * Hook to access information about the currently connected wallet
+ *
+ * @remarks
+ * This hook provides access to metadata about the connected wallet, such as its name,
+ * icon, and other identifying information. It automatically subscribes to wallet info
+ * changes via valtio.
+ *
+ * @returns An object containing:
+ *   - `walletInfo`: Metadata about the currently connected wallet (name, icon, etc.)
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { walletInfo } = useWalletInfo();
+ *
+ *   return (
+ *     <View>
+ *       {walletInfo && (
+ *         <>
+ *           <Image source={{ uri: walletInfo.icon }} />
+ *           <Text>{walletInfo.name}</Text>
+ *         </>
+ *       )}
+ *     </View>
+ *   );
+ * }
+ * ```
+ *
+ * @throws {Error} If used outside of an AppKitProvider
+ */
 export function useWalletInfo() {
-  useAppKit(); // Use the hook for checks
+  useAppKitContext();
   const { walletInfo: walletInfoSnapshot } = useSnapshot(ConnectionsController.state);
 
   const walletInfo = useMemo(() => ({ walletInfo: walletInfoSnapshot }), [walletInfoSnapshot]);

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -32,6 +32,7 @@ export type { AppKitConfig } from './types';
 export { useAppKit } from './hooks/useAppKit';
 export { useProvider } from './hooks/useProvider';
 export { useAccount, type Account as UseAccountReturn } from './hooks/useAccount';
+export { useAppKitTheme, type UseAppKitThemeReturn } from './hooks/useAppKitTheme';
 export { useWalletInfo } from './hooks/useWalletInfo';
 export { useAppKitEvents, useAppKitEventSubscription } from './hooks/useAppKitEvents';
 export { useAppKitState } from './hooks/useAppKitState';

--- a/packages/appkit/src/partials/w3m-connecting-qrcode/index.tsx
+++ b/packages/appkit/src/partials/w3m-connecting-qrcode/index.tsx
@@ -21,7 +21,7 @@ import { ReownButton } from './components/ReownButton';
 import { useWindowDimensions } from 'react-native';
 
 const LOGO_SIZE = 60;
-const LOGO_BORDER_RADIUS = 20;
+const LOGO_BORDER_RADIUS = 12;
 
 export function ConnectingQrCode() {
   const { height, width } = useWindowDimensions();

--- a/packages/core/src/__tests__/controllers/ThemeController.test.ts
+++ b/packages/core/src/__tests__/controllers/ThemeController.test.ts
@@ -1,19 +1,142 @@
+import { Appearance } from 'react-native';
 import { ThemeController } from '../../index';
+
+// Mock react-native Appearance
+jest.mock('react-native', () => ({
+  Appearance: {
+    getColorScheme: jest.fn()
+  }
+}));
+
+const mockedAppearance = Appearance as jest.Mocked<typeof Appearance>;
 
 // -- Tests --------------------------------------------------------------------
 describe('ThemeController', () => {
-  it('should have valid default state', () => {
-    expect(ThemeController.state).toEqual({
-      themeMode: undefined,
-      themeVariables: undefined
+  beforeEach(() => {
+    // Reset state before each test
+    ThemeController.setThemeMode(undefined);
+    ThemeController.setDefaultThemeMode(undefined);
+    ThemeController.setThemeVariables(undefined);
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should have valid default state', () => {
+      expect(ThemeController.state.themeMode).toBeDefined();
+      expect(ThemeController.state.defaultThemeMode).toBeUndefined();
+      expect(ThemeController.state.themeVariables).toEqual({});
     });
   });
 
-  it('should update state correctly when changing theme', () => {
-    ThemeController.setThemeMode('light');
-    expect(ThemeController.state).toEqual({
-      themeMode: 'light',
-      themeVariables: undefined
+  describe('setThemeMode', () => {
+    it('should set theme mode to light', () => {
+      ThemeController.setThemeMode('light');
+      expect(ThemeController.state.themeMode).toBe('light');
+    });
+
+    it('should set theme mode to dark', () => {
+      ThemeController.setThemeMode('dark');
+      expect(ThemeController.state.themeMode).toBe('dark');
+    });
+
+    it('should fall back to system theme when undefined and system is dark', () => {
+      mockedAppearance.getColorScheme.mockReturnValue('dark');
+      ThemeController.setThemeMode(undefined);
+      expect(ThemeController.state.themeMode).toBe('dark');
+      expect(mockedAppearance.getColorScheme).toHaveBeenCalled();
+    });
+
+    it('should fall back to system theme when undefined and system is light', () => {
+      mockedAppearance.getColorScheme.mockReturnValue('light');
+      ThemeController.setThemeMode(undefined);
+      expect(ThemeController.state.themeMode).toBe('light');
+      expect(mockedAppearance.getColorScheme).toHaveBeenCalled();
+    });
+
+    it('should default to light when system returns null', () => {
+      mockedAppearance.getColorScheme.mockReturnValue(null);
+      ThemeController.setThemeMode(undefined);
+      expect(ThemeController.state.themeMode).toBe('light');
+    });
+  });
+
+  describe('setDefaultThemeMode', () => {
+    it('should set default theme mode and apply it', () => {
+      ThemeController.setDefaultThemeMode('dark');
+      expect(ThemeController.state.defaultThemeMode).toBe('dark');
+      expect(ThemeController.state.themeMode).toBe('dark');
+    });
+
+    it('should set default theme mode to light and apply it', () => {
+      ThemeController.setDefaultThemeMode('light');
+      expect(ThemeController.state.defaultThemeMode).toBe('light');
+      expect(ThemeController.state.themeMode).toBe('light');
+    });
+
+    it('should set default theme mode to undefined and fall back to system', () => {
+      mockedAppearance.getColorScheme.mockReturnValue('dark');
+      ThemeController.setDefaultThemeMode(undefined);
+      expect(ThemeController.state.defaultThemeMode).toBeUndefined();
+      expect(ThemeController.state.themeMode).toBe('dark');
+    });
+  });
+
+  describe('setThemeVariables', () => {
+    it('should set theme variables', () => {
+      const variables = { accent: '#000000' };
+      ThemeController.setThemeVariables(variables);
+      expect(ThemeController.state.themeVariables).toEqual(variables);
+    });
+
+    it('should override existing theme variables', () => {
+      const initialVariables = { accent: '#000000' };
+      const newVariables = { accent: '#FFFFFF' };
+
+      ThemeController.setThemeVariables(initialVariables);
+      ThemeController.setThemeVariables(newVariables);
+
+      expect(ThemeController.state.themeVariables).toEqual({
+        accent: '#FFFFFF'
+      });
+    });
+
+    it('should reset theme variables when undefined', () => {
+      const variables = { accent: '#000000' };
+      ThemeController.setThemeVariables(variables);
+      expect(ThemeController.state.themeVariables).toEqual(variables);
+
+      ThemeController.setThemeVariables(undefined);
+      expect(ThemeController.state.themeVariables).toEqual({});
+    });
+
+    it('should handle empty object', () => {
+      ThemeController.setThemeVariables({});
+      expect(ThemeController.state.themeVariables).toEqual({});
+    });
+  });
+
+  describe('subscribe', () => {
+    it('should return an unsubscribe function', () => {
+      const callback = jest.fn();
+      const unsubscribe = ThemeController.subscribe(callback);
+
+      expect(typeof unsubscribe).toBe('function');
+
+      unsubscribe();
+    });
+
+    it('should have subscribe method defined', () => {
+      expect(ThemeController.subscribe).toBeDefined();
+      expect(typeof ThemeController.subscribe).toBe('function');
+    });
+  });
+
+  describe('state immutability', () => {
+    it('should maintain state reference but update values', () => {
+      const stateRef = ThemeController.state;
+      ThemeController.setThemeMode('dark');
+      expect(ThemeController.state).toBe(stateRef);
+      expect(ThemeController.state.themeMode).toBe('dark');
     });
   });
 });

--- a/packages/core/src/__tests__/controllers/ThemeController.test.ts
+++ b/packages/core/src/__tests__/controllers/ThemeController.test.ts
@@ -5,7 +5,7 @@ describe('ThemeController', () => {
   it('should have valid default state', () => {
     expect(ThemeController.state).toEqual({
       themeMode: undefined,
-      themeVariables: {}
+      themeVariables: undefined
     });
   });
 
@@ -13,7 +13,7 @@ describe('ThemeController', () => {
     ThemeController.setThemeMode('light');
     expect(ThemeController.state).toEqual({
       themeMode: 'light',
-      themeVariables: {}
+      themeVariables: undefined
     });
   });
 });

--- a/packages/core/src/__tests__/controllers/ThemeController.test.ts
+++ b/packages/core/src/__tests__/controllers/ThemeController.test.ts
@@ -14,9 +14,9 @@ const mockedAppearance = Appearance as jest.Mocked<typeof Appearance>;
 describe('ThemeController', () => {
   beforeEach(() => {
     // Reset state before each test
-    ThemeController.setThemeMode(undefined);
-    ThemeController.setDefaultThemeMode(undefined);
-    ThemeController.setThemeVariables(undefined);
+    ThemeController.setThemeMode();
+    ThemeController.setDefaultThemeMode();
+    ThemeController.setThemeVariables();
     jest.clearAllMocks();
   });
 
@@ -41,21 +41,21 @@ describe('ThemeController', () => {
 
     it('should fall back to system theme when undefined and system is dark', () => {
       mockedAppearance.getColorScheme.mockReturnValue('dark');
-      ThemeController.setThemeMode(undefined);
+      ThemeController.setThemeMode();
       expect(ThemeController.state.themeMode).toBe('dark');
       expect(mockedAppearance.getColorScheme).toHaveBeenCalled();
     });
 
     it('should fall back to system theme when undefined and system is light', () => {
       mockedAppearance.getColorScheme.mockReturnValue('light');
-      ThemeController.setThemeMode(undefined);
+      ThemeController.setThemeMode();
       expect(ThemeController.state.themeMode).toBe('light');
       expect(mockedAppearance.getColorScheme).toHaveBeenCalled();
     });
 
     it('should default to light when system returns null', () => {
       mockedAppearance.getColorScheme.mockReturnValue(null);
-      ThemeController.setThemeMode(undefined);
+      ThemeController.setThemeMode();
       expect(ThemeController.state.themeMode).toBe('light');
     });
   });
@@ -75,7 +75,7 @@ describe('ThemeController', () => {
 
     it('should set default theme mode to undefined and fall back to system', () => {
       mockedAppearance.getColorScheme.mockReturnValue('dark');
-      ThemeController.setDefaultThemeMode(undefined);
+      ThemeController.setDefaultThemeMode();
       expect(ThemeController.state.defaultThemeMode).toBeUndefined();
       expect(ThemeController.state.themeMode).toBe('dark');
     });

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -13,7 +13,7 @@ export interface ThemeControllerState {
 const state = proxy<ThemeControllerState>({
   themeMode: undefined,
   defaultThemeMode: undefined,
-  themeVariables: {}
+  themeVariables: undefined
 });
 
 // -- Controller ---------------------------------------- //
@@ -39,7 +39,9 @@ export const ThemeController = {
 
   setThemeVariables(themeVariables: ThemeControllerState['themeVariables']) {
     if (!themeVariables) {
-      state.themeVariables = {};
+      state.themeVariables = undefined;
+
+      return;
     }
 
     state.themeVariables = { ...state.themeVariables, ...themeVariables };

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -38,7 +38,7 @@ export const ThemeController = {
   },
 
   setThemeVariables(themeVariables?: ThemeControllerState['themeVariables']) {
-    if (!themeVariables) {
+    if (Object.keys(themeVariables ?? {}).length === 0) {
       state.themeVariables = {};
 
       return;

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -2,18 +2,16 @@ import { Appearance } from 'react-native';
 import { proxy, subscribe as sub } from 'valtio';
 import type { ThemeMode, ThemeVariables } from '@reown/appkit-common-react-native';
 
-const systemThemeMode = Appearance.getColorScheme() as ThemeMode;
-
 // -- Types --------------------------------------------- //
 export interface ThemeControllerState {
-  themeMode: ThemeMode;
+  themeMode?: ThemeMode;
   defaultThemeMode?: ThemeMode;
   themeVariables: ThemeVariables;
 }
 
 // -- State --------------------------------------------- //
 const state = proxy<ThemeControllerState>({
-  themeMode: systemThemeMode,
+  themeMode: undefined,
   defaultThemeMode: undefined,
   themeVariables: {}
 });
@@ -28,16 +26,15 @@ export const ThemeController = {
 
   setThemeMode(themeMode?: ThemeControllerState['themeMode']) {
     if (!themeMode) {
-      state.themeMode = Appearance.getColorScheme() as ThemeMode;
+      state.themeMode = (Appearance.getColorScheme() ?? 'light') as ThemeMode;
     } else {
       state.themeMode = themeMode;
     }
   },
 
   setDefaultThemeMode(themeMode?: ThemeControllerState['defaultThemeMode']) {
-    const _systemThemeMode = Appearance.getColorScheme() as ThemeMode;
-    state.defaultThemeMode = themeMode ?? _systemThemeMode;
-    this.setThemeMode(themeMode ?? _systemThemeMode);
+    state.defaultThemeMode = themeMode;
+    this.setThemeMode(themeMode);
   },
 
   setThemeVariables(themeVariables?: ThemeControllerState['themeVariables']) {

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -2,18 +2,20 @@ import { Appearance } from 'react-native';
 import { proxy, subscribe as sub } from 'valtio';
 import type { ThemeMode, ThemeVariables } from '@reown/appkit-common-react-native';
 
+const systemThemeMode = Appearance.getColorScheme() as ThemeMode;
+
 // -- Types --------------------------------------------- //
 export interface ThemeControllerState {
-  themeMode?: ThemeMode;
+  themeMode: ThemeMode;
   defaultThemeMode?: ThemeMode;
-  themeVariables?: ThemeVariables;
+  themeVariables: ThemeVariables;
 }
 
 // -- State --------------------------------------------- //
 const state = proxy<ThemeControllerState>({
-  themeMode: undefined,
+  themeMode: systemThemeMode,
   defaultThemeMode: undefined,
-  themeVariables: undefined
+  themeVariables: {}
 });
 
 // -- Controller ---------------------------------------- //
@@ -24,7 +26,7 @@ export const ThemeController = {
     return sub(state, () => callback(state));
   },
 
-  setThemeMode(themeMode: ThemeControllerState['themeMode']) {
+  setThemeMode(themeMode?: ThemeControllerState['themeMode']) {
     if (!themeMode) {
       state.themeMode = Appearance.getColorScheme() as ThemeMode;
     } else {
@@ -32,14 +34,15 @@ export const ThemeController = {
     }
   },
 
-  setDefaultThemeMode(themeMode: ThemeControllerState['defaultThemeMode']) {
-    state.defaultThemeMode = themeMode;
-    this.setThemeMode(themeMode);
+  setDefaultThemeMode(themeMode?: ThemeControllerState['defaultThemeMode']) {
+    const _systemThemeMode = Appearance.getColorScheme() as ThemeMode;
+    state.defaultThemeMode = themeMode ?? _systemThemeMode;
+    this.setThemeMode(themeMode ?? _systemThemeMode);
   },
 
-  setThemeVariables(themeVariables: ThemeControllerState['themeVariables']) {
+  setThemeVariables(themeVariables?: ThemeControllerState['themeVariables']) {
     if (!themeVariables) {
-      state.themeVariables = undefined;
+      state.themeVariables = {};
 
       return;
     }

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -38,7 +38,7 @@ export const ThemeController = {
   },
 
   setThemeVariables(themeVariables?: ThemeControllerState['themeVariables']) {
-    if (Object.keys(themeVariables ?? {}).length === 0) {
+    if (!themeVariables) {
       state.themeVariables = {};
 
       return;


### PR DESCRIPTION
This pull request introduces a new hook, `useAppKitTheme`, to the AppKit React Native ecosystem, enabling developers to control and customize the theme mode (light/dark) and accent color of the AppKit modal. The hook provides an interface for reading and updating theme settings, improving theming flexibility and integration with host applications.

The most important changes are:

**New Feature: Theme Control Hook**
* Added the `useAppKitTheme` hook in `packages/appkit/src/hooks/useAppKitTheme.ts`, allowing consumers to get and set the current theme mode and accent color for AppKit modals. The hook provides a typed API and is documented with usage examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `useAppKitTheme` and a shared `useAppKitContext`, refactor hooks to use it, and enhance `ThemeController` with defaults and tests.
> 
> - **AppKit (React Native)**
>   - **New Hook**: Add `useAppKitTheme` (`packages/appkit/src/hooks/useAppKitTheme.ts`) and export from `src/index.ts`.
>   - **Context**: Add `useAppKitContext` and refactor `useAccount`, `useAppKit`, `useAppKitEvents`, `useAppKitLogs`, `useAppKitState`, `useProvider`, `useWalletInfo` to use it for provider-scope checks.
>   - **AppKitContext**: Export `AppKitContextType` and keep provider wiring.
>   - **Tests/Config**: Add `jest.config.ts`, `jest-setup.ts`, and `babel.config.js`; add tests for `useAppKitTheme`.
> - **Core**
>   - **ThemeController**: Make `themeVariables` non-optional; add `defaultThemeMode`; update `setThemeMode` to fallback to system (default light); support resetting `setThemeVariables`; add/expand tests.
> - **Repo**
>   - Scripts: Remove build step from root `test` script; add `test` script to `packages/appkit/package.json`.
>   - Changeset: Patch bump across `@reown/*` packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e74084ec0ae76a386b6e671a482d83b517636d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->