### PR TITLE
fix: renew uri after failure

### DIFF
--- a/.changeset/cool-parks-slide.md
+++ b/.changeset/cool-parks-slide.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+fix: renew uri after failure

--- a/packages/appkit/src/partials/w3m-connecting-body/index.tsx
+++ b/packages/appkit/src/partials/w3m-connecting-body/index.tsx
@@ -11,7 +11,9 @@ export interface ConnectingBodyProps {
 export function ConnectingBody({ title, description }: ConnectingBodyProps) {
   return (
     <FlexView padding={['3xs', '2xl', '0', '2xl']} alignItems="center" style={styles.textContainer}>
-      <Text variant="paragraph-500">{title}</Text>
+      <Text center numberOfLines={1} variant="paragraph-500">
+        {title}
+      </Text>
       {description ? (
         <Text center variant="small-400" color="fg-200" style={styles.descriptionText}>
           {description}

--- a/packages/appkit/src/partials/w3m-connecting-mobile/components/StoreLink.tsx
+++ b/packages/appkit/src/partials/w3m-connecting-mobile/components/StoreLink.tsx
@@ -12,7 +12,7 @@ export function StoreLink({ visible, walletName = 'Wallet', onPress }: StoreLink
 
   return (
     <ActionEntry style={styles.storeButton}>
-      <Text numberOfLines={1} variant="paragraph-500" color="fg-200">
+      <Text numberOfLines={1} style={styles.storeText} variant="paragraph-500" color="fg-200">
         {`Don't have ${walletName}?`}
       </Text>
       <Button
@@ -34,5 +34,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.l,
     marginHorizontal: Spacing.xl,
     marginTop: Spacing.l
+  },
+  storeText: {
+    flexShrink: 1
   }
 });

--- a/packages/appkit/src/partials/w3m-header/index.tsx
+++ b/packages/appkit/src/partials/w3m-header/index.tsx
@@ -100,7 +100,12 @@ export function Header() {
       padding={['l', 'xl', bottomPadding, 'xl']}
     >
       {dynamicButtonTemplate()}
-      <Text variant="paragraph-600" numberOfLines={1} testID="header-text">
+      <Text
+        variant="paragraph-600"
+        numberOfLines={1}
+        style={styles.headerText}
+        testID="header-text"
+      >
         {header}
       </Text>
       {showClose ? (

--- a/packages/appkit/src/partials/w3m-header/styles.ts
+++ b/packages/appkit/src/partials/w3m-header/styles.ts
@@ -4,5 +4,8 @@ export default StyleSheet.create({
   iconPlaceholder: {
     height: 32,
     width: 32
+  },
+  headerText: {
+    flexShrink: 1
   }
 });

--- a/packages/appkit/src/views/w3m-connecting-external-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-external-view/index.tsx
@@ -26,6 +26,7 @@ import styles from './styles';
 import { useInternalAppKit } from '../../AppKitContext';
 import { StoreLink } from '../../partials/w3m-connecting-mobile/components/StoreLink';
 import { WcHelpersUtil } from '../../utils/HelpersUtil';
+import { ErrorUtil } from '@reown/appkit-common-react-native';
 
 export function ConnectingExternalView() {
   const { data } = useSnapshot(RouterController.state);
@@ -94,16 +95,11 @@ export function ConnectingExternalView() {
       }
     } catch (error) {
       LogController.sendError(error, 'ConnectingExternalView.tsx', 'onConnect');
-      if (/(Wallet not found)/i.test((error as Error).message)) {
-        setErrorType('not_installed');
-      } else if (/(rejected)/i.test((error as Error).message)) {
-        setErrorType('declined');
-      } else {
-        setErrorType('default');
-      }
+      const type = ErrorUtil.categorizeConnectionError(error);
+      setErrorType(type);
       EventsController.sendEvent({
         type: 'track',
-        event: 'CONNECT_ERROR',
+        event: type === 'declined' ? 'USER_REJECTED' : 'CONNECT_ERROR',
         properties: { message: (error as Error)?.message ?? 'Unknown' }
       });
     }

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -1,6 +1,6 @@
 import { useSnapshot } from 'valtio';
 import { useEffect, useLayoutEffect, useState } from 'react';
-import { type Platform } from '@reown/appkit-common-react-native';
+import { ErrorUtil, type Platform } from '@reown/appkit-common-react-native';
 import {
   WcController,
   ConstantsUtil,
@@ -43,26 +43,37 @@ export function ConnectingView() {
     try {
       const { wcPairingExpiry } = WcController.state;
       const { data: routeData } = RouterController.state;
-      if (retry || CoreHelperUtil.isPairingExpired(wcPairingExpiry)) {
+      const isPairingExpired = CoreHelperUtil.isPairingExpired(wcPairingExpiry);
+      if (retry || isPairingExpired) {
         WcController.setWcError(false);
 
         const connectPromise = connect({
           wallet: routeData?.wallet
         });
         WcController.setWcPromise(connectPromise);
+        await connectPromise;
       }
     } catch (error) {
       LogController.sendError(error, 'ConnectingView.tsx', 'initializeConnection');
       WcController.setWcError(true);
       WcController.clearUri();
-      SnackController.showError('Declined');
+
       if (isQr && CoreHelperUtil.isAllowedRetry(lastRetry)) {
         setLastRetry(Date.now());
         initializeConnection(true);
       }
+
+      const isUserRejected = ErrorUtil.isUserRejectedRequestError(error);
+      const isProposalExpired = ErrorUtil.isProposalExpiredError(error);
+      if (!isProposalExpired) {
+        SnackController.showError(
+          isUserRejected ? 'User rejected the request' : 'Something went wrong'
+        );
+      }
+
       EventsController.sendEvent({
         type: 'track',
-        event: 'CONNECT_ERROR',
+        event: isUserRejected ? 'USER_REJECTED' : 'CONNECT_ERROR',
         properties: {
           message: (error as Error)?.message ?? 'Unknown'
         }

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -61,6 +61,8 @@ export function ConnectingView() {
       if (isQr && CoreHelperUtil.isAllowedRetry(lastRetry)) {
         setLastRetry(Date.now());
         initializeConnection(true);
+
+        return;
       }
 
       const isUserRejected = ErrorUtil.isUserRejectedRequestError(error);

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -39,7 +39,7 @@ export function ConnectingView() {
     }
   };
 
-  const initializeConnection = async (retry = false) => {
+  const initializeConnection = async (retry = false, retryTimestamp?: number) => {
     try {
       const { wcPairingExpiry } = WcController.state;
       const { data: routeData } = RouterController.state;
@@ -58,9 +58,12 @@ export function ConnectingView() {
       WcController.setWcError(true);
       WcController.clearUri();
 
-      if (isQr && CoreHelperUtil.isAllowedRetry(lastRetry)) {
-        setLastRetry(Date.now());
-        initializeConnection(true);
+      const currentRetryTime = retryTimestamp ?? lastRetry;
+
+      if (isQr && CoreHelperUtil.isAllowedRetry(currentRetryTime)) {
+        const newRetryTime = Date.now();
+        setLastRetry(newRetryTime);
+        initializeConnection(true, newRetryTime);
 
         return;
       }

--- a/packages/common/src/types/api/events.ts
+++ b/packages/common/src/types/api/events.ts
@@ -33,6 +33,7 @@ export type EventName =
   | 'SELECT_WALLET'
   | 'CONNECT_SUCCESS'
   | 'CONNECT_ERROR'
+  | 'USER_REJECTED'
   | 'DISCONNECT_SUCCESS'
   | 'DISCONNECT_ERROR'
   | 'CLICK_WALLET_HELP'
@@ -149,6 +150,14 @@ export type Event =
   | {
       type: 'track';
       event: 'CONNECT_ERROR';
+      properties: {
+        message: string;
+      };
+    }
+  | {
+      type: 'track';
+      address?: string;
+      event: 'USER_REJECTED';
       properties: {
         message: string;
       };

--- a/packages/common/src/utils/ErrorUtil.ts
+++ b/packages/common/src/utils/ErrorUtil.ts
@@ -1,8 +1,7 @@
 export const ErrorUtil = {
   RPC_ERROR_CODE: {
     USER_REJECTED_REQUEST: 4001,
-    USER_REJECTED_METHODS: 5002,
-    USER_REJECTED: 5000
+    USER_REJECTED_METHODS: 5002
   } as const,
   UniversalProviderErrors: {
     UNAUTHORIZED_DOMAIN_NOT_ALLOWED: {
@@ -37,7 +36,7 @@ export const ErrorUtil = {
       longMessage: 'Project ID Not Configured - update configuration'
     }
   },
-  isRpcProviderError(error: any) {
+  isRpcProviderError(error: any): error is { message: string; code: number } {
     try {
       if (typeof error === 'object' && error !== null) {
         const objErr = error as Record<string, unknown>;
@@ -55,7 +54,7 @@ export const ErrorUtil = {
   },
   isUserRejectedMessage(message: string) {
     return (
-      message.toLowerCase().includes('user rejected') ||
+      message.toLowerCase().includes('rejected') ||
       message.toLowerCase().includes('user cancelled') ||
       message.toLowerCase().includes('user canceled')
     );
@@ -80,6 +79,35 @@ export const ErrorUtil = {
     return false;
   },
   isProposalExpiredError(error: any) {
-    return error?.message?.includes('expired');
+    if (ErrorUtil.isRpcProviderError(error)) {
+      return error.message?.toLowerCase().includes('proposal expired');
+    }
+
+    if (error) {
+      return (
+        typeof error?.message === 'string' &&
+        error.message?.toLowerCase().includes('proposal expired')
+      );
+    }
+
+    return false;
+  },
+  isWalletNotFoundError(error: any) {
+    if (error && typeof error?.message === 'string') {
+      return /wallet not found/i.test(error.message);
+    }
+
+    return false;
+  },
+  categorizeConnectionError(error: any): 'not_installed' | 'declined' | 'default' {
+    if (ErrorUtil.isWalletNotFoundError(error)) {
+      return 'not_installed';
+    }
+
+    if (ErrorUtil.isUserRejectedRequestError(error)) {
+      return 'declined';
+    }
+
+    return 'default';
   }
 };

--- a/packages/common/src/utils/ErrorUtil.ts
+++ b/packages/common/src/utils/ErrorUtil.ts
@@ -1,4 +1,9 @@
 export const ErrorUtil = {
+  RPC_ERROR_CODE: {
+    USER_REJECTED_REQUEST: 4001,
+    USER_REJECTED_METHODS: 5002,
+    USER_REJECTED: 5000
+  } as const,
   UniversalProviderErrors: {
     UNAUTHORIZED_DOMAIN_NOT_ALLOWED: {
       message: 'Unauthorized: origin not allowed',
@@ -31,5 +36,50 @@ export const ErrorUtil = {
       shortMessage: 'Project ID Not Configured',
       longMessage: 'Project ID Not Configured - update configuration'
     }
+  },
+  isRpcProviderError(error: any) {
+    try {
+      if (typeof error === 'object' && error !== null) {
+        const objErr = error as Record<string, unknown>;
+
+        const hasMessage = typeof objErr['message'] === 'string';
+        const hasCode = typeof objErr['code'] === 'number';
+
+        return hasMessage && hasCode;
+      }
+
+      return false;
+    } catch {
+      return false;
+    }
+  },
+  isUserRejectedMessage(message: string) {
+    return (
+      message.toLowerCase().includes('user rejected') ||
+      message.toLowerCase().includes('user cancelled') ||
+      message.toLowerCase().includes('user canceled')
+    );
+  },
+  isUserRejectedRequestError(error: any) {
+    if (ErrorUtil.isRpcProviderError(error)) {
+      const isUserRejectedCode = error.code === ErrorUtil.RPC_ERROR_CODE.USER_REJECTED_REQUEST;
+      const isUserRejectedMethodsCode =
+        error?.code === ErrorUtil.RPC_ERROR_CODE.USER_REJECTED_METHODS;
+
+      return (
+        isUserRejectedCode ||
+        isUserRejectedMethodsCode ||
+        ErrorUtil.isUserRejectedMessage(error.message)
+      );
+    }
+
+    if (error instanceof Error) {
+      return ErrorUtil.isUserRejectedMessage(error.message);
+    }
+
+    return false;
+  },
+  isProposalExpiredError(error: any) {
+    return error?.message?.includes('expired');
   }
 };

--- a/packages/common/src/utils/ErrorUtil.ts
+++ b/packages/common/src/utils/ErrorUtil.ts
@@ -63,7 +63,7 @@ export const ErrorUtil = {
     if (ErrorUtil.isRpcProviderError(error)) {
       const isUserRejectedCode = error.code === ErrorUtil.RPC_ERROR_CODE.USER_REJECTED_REQUEST;
       const isUserRejectedMethodsCode =
-        error?.code === ErrorUtil.RPC_ERROR_CODE.USER_REJECTED_METHODS;
+        error.code === ErrorUtil.RPC_ERROR_CODE.USER_REJECTED_METHODS;
 
       return (
         isUserRejectedCode ||


### PR DESCRIPTION
This pull request introduces improved error handling and event tracking for user-initiated rejection and proposal expiry during wallet connection flows. The changes add new utility methods for error identification, update event types to distinguish between general connection errors and user rejections, and enhance user feedback in the UI.

**Error handling improvements:**

* Added new methods to `ErrorUtil` (`isRpcProviderError`, `isUserRejectedMessage`, `isUserRejectedRequestError`, `isProposalExpiredError`) to more accurately identify user rejection and proposal expiry errors. Also defined new RPC error codes for user rejection scenarios. [[1]](diffhunk://#diff-04667b9abeaf05d8d2df8be1c402221bae594cd2e223a33a11d0731bd9a2735fR2-R6) [[2]](diffhunk://#diff-04667b9abeaf05d8d2df8be1c402221bae594cd2e223a33a11d0731bd9a2735fR39-R83)

**UI and feedback enhancements:**

* Updated the `ConnectingView` component to use the new error utility methods for distinguishing between user rejection and other errors. Now shows a specific error message ("User rejected the request") when appropriate, and only displays generic errors for other cases. [[1]](diffhunk://#diff-b85edf15440f34aec7e1d7d62a97e8cbc3a25f33b793d075ac7103602d36da42L3-R3) [[2]](diffhunk://#diff-b85edf15440f34aec7e1d7d62a97e8cbc3a25f33b793d075ac7103602d36da42L46-R76)

**Event tracking updates:**

* Added a new event type `'USER_REJECTED'` to the `EventName` union and corresponding event object to the `Event` type, allowing the system to track user-initiated rejection separately from general connection errors. [[1]](diffhunk://#diff-f789d781b378dfd9b7662f7eb59d9bf09beb81835145b610622c88fee4652d9cR36) [[2]](diffhunk://#diff-f789d781b378dfd9b7662f7eb59d9bf09beb81835145b610622c88fee4652d9cR157-R164)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renews WalletConnect URI on failures, adds user-rejection error utilities and event, updates connecting views to use them, and tweaks text truncation in UI.
> 
> - **Connection flow**:
>   - Renew WC URI on errors; await `connect` promise and auto-retry for QR with timestamp guard.
>   - Use `ErrorUtil` to distinguish user rejection vs other/proposal-expired errors; show specific snackbars and map to `USER_REJECTED` vs `CONNECT_ERROR` events.
> - **Common utils**:
>   - Add `ErrorUtil` RPC codes and helpers: `isRpcProviderError`, `isUserRejectedMessage`, `isUserRejectedRequestError`, `isProposalExpiredError`, `isWalletNotFoundError`, `categorizeConnectionError`.
> - **Events/types**:
>   - Extend `EventName` and `Event` with `USER_REJECTED` tracking.
> - **UI**:
>   - Make `ConnectingBody` title centered and single-line; add `flexShrink` to header/store texts to prevent truncation issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c49ea8de4ac834273ccc9173e7f3ff7829c945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->