### PR TITLE
fix: show rejection alert in case the user rejects the connection

### DIFF
--- a/examples/expo-multichain/package-lock.json
+++ b/examples/expo-multichain/package-lock.json
@@ -11199,9 +11199,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.2.tgz",
-      "integrity": "sha512-p6fyzl+mQo6uhESLxbF5WlBOAJMDh36PljwlKtP5V1v09NxlqGru3ShK+4wKhSuhuYf8qxMmrivHOa/M7q0sMg==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.3.tgz",
+      "integrity": "sha512-2LOYWUbnhdxdL8MNbNg9XZig6k+cZXm5IjHn2Aviv7honhBMOHb+jxrKIeJRZJRmn+htUCKhaicxwXuUDlchRA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/examples/expo-multichain/package.json
+++ b/examples/expo-multichain/package.json
@@ -76,7 +76,8 @@
     "typescript": "~5.9.2"
   },
   "overrides": {
-    "react": "19.1.0"
+    "react": "19.1.0",
+    "hono": "4.10.3"
   },
   "private": true
 }

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -56,17 +56,6 @@ export function ConnectingView() {
     } catch (error) {
       LogController.sendError(error, 'ConnectingView.tsx', 'initializeConnection');
       WcController.setWcError(true);
-      WcController.clearUri();
-
-      const currentRetryTime = retryTimestamp ?? lastRetry;
-
-      if (isQr && CoreHelperUtil.isAllowedRetry(currentRetryTime)) {
-        const newRetryTime = Date.now();
-        setLastRetry(newRetryTime);
-        initializeConnection(true, newRetryTime);
-
-        return;
-      }
 
       const isUserRejected = ErrorUtil.isUserRejectedRequestError(error);
       const isProposalExpired = ErrorUtil.isProposalExpiredError(error);
@@ -83,6 +72,13 @@ export function ConnectingView() {
           message: (error as Error)?.message ?? 'Unknown'
         }
       });
+
+      const currentRetryTime = retryTimestamp ?? lastRetry;
+      if (isQr && CoreHelperUtil.isAllowedRetry(currentRetryTime)) {
+        const newRetryTime = Date.now();
+        setLastRetry(newRetryTime);
+        initializeConnection(true, newRetryTime);
+      }
     }
   };
 

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -32,7 +32,6 @@ export function ConnectingView() {
   const onRetry = () => {
     if (CoreHelperUtil.isAllowedRetry(lastRetry)) {
       setLastRetry(Date.now());
-      WcController.clearUri();
       initializeConnection(true);
     } else {
       SnackController.showError('Please wait a second before retrying');
@@ -46,6 +45,7 @@ export function ConnectingView() {
       const isPairingExpired = CoreHelperUtil.isPairingExpired(wcPairingExpiry);
       if (retry || isPairingExpired) {
         WcController.setWcError(false);
+        WcController.clearUri();
 
         const connectPromise = connect({
           wallet: routeData?.wallet


### PR DESCRIPTION
This pull request refactors the retry logic in the `ConnectingView` component to improve error handling and code clarity. The main change is moving the QR code retry logic from the error catch block to after the error modal is displayed, ensuring that retries are only attempted after user feedback.

**Error handling and retry logic improvements:**

* Moved the QR code retry logic to execute after the error modal is displayed, rather than immediately upon catching an error, making the flow clearer and more user-friendly. [[1]](diffhunk://#diff-b85edf15440f34aec7e1d7d62a97e8cbc3a25f33b793d075ac7103602d36da42L59-L69) [[2]](diffhunk://#diff-b85edf15440f34aec7e1d7d62a97e8cbc3a25f33b793d075ac7103602d36da42R75-R81)
* Removed redundant calls to `WcController.clearUri()` and the previous retry logic from the catch block, streamlining error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors ConnectingView to clear the URI before reconnect and run QR retries after showing errors, and bumps hono to 4.10.3.
> 
> - **AppKit `ConnectingView`**:
>   - Clear `wc` URI via `WcController.clearUri()` before initiating reconnect when retrying or pairing expired.
>   - Remove `clearUri` from `onRetry` and catch block; move QR retry to execute after error notification and event tracking.
>   - Preserve timed QR auto-retry using `isAllowedRetry` with updated retry timestamp handling.
> - **Examples / Dependencies**:
>   - Add `overrides` entry for `hono` `4.10.3` in `examples/expo-multichain/package.json` and update lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b73fdb4a32ac3080b3761cbfdd4900835755d156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->