### PR TITLE
fix: clear old uri before creating a new one on connecting view

### DIFF
--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -1,5 +1,5 @@
 import { useSnapshot } from 'valtio';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ErrorUtil, type Platform } from '@reown/appkit-common-react-native';
 import {
   WcController,
@@ -22,7 +22,7 @@ export function ConnectingView() {
   const { connect } = useInternalAppKit();
   const { installed } = useSnapshot(ApiController.state);
   const { data } = RouterController.state;
-  const [lastRetry, setLastRetry] = useState(Date.now());
+  const lastRetryRef = useRef<number>(Date.now());
   const isQr = !data?.wallet;
   const isInstalled = !!installed?.find(wallet => wallet.id === data?.wallet?.id);
 
@@ -30,8 +30,8 @@ export function ConnectingView() {
   const [platforms, setPlatforms] = useState<Platform[]>([]);
 
   const onRetry = () => {
-    if (CoreHelperUtil.isAllowedRetry(lastRetry)) {
-      setLastRetry(Date.now());
+    if (CoreHelperUtil.isAllowedRetry(lastRetryRef.current)) {
+      lastRetryRef.current = Date.now();
       initializeConnection(true);
     } else {
       SnackController.showError('Please wait a second before retrying');
@@ -73,10 +73,10 @@ export function ConnectingView() {
         }
       });
 
-      const currentRetryTime = retryTimestamp ?? lastRetry;
+      const currentRetryTime = retryTimestamp ?? lastRetryRef.current;
       if (isQr && CoreHelperUtil.isAllowedRetry(currentRetryTime)) {
         const newRetryTime = Date.now();
-        setLastRetry(newRetryTime);
+        lastRetryRef.current = newRetryTime;
         initializeConnection(true, newRetryTime);
       }
     }

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -107,6 +107,9 @@ export function ConnectingView() {
   }, [data, isInstalled]);
 
   useEffect(() => {
+    // Clear any stale URI from previous connection attempts
+    WcController.clearUri();
+
     initializeConnection();
     let _interval: NodeJS.Timeout;
 

--- a/packages/appkit/src/views/w3m-connecting-view/index.tsx
+++ b/packages/appkit/src/views/w3m-connecting-view/index.tsx
@@ -38,7 +38,7 @@ export function ConnectingView() {
     }
   };
 
-  const initializeConnection = async (retry = false, retryTimestamp?: number) => {
+  const initializeConnection = async (retry = false) => {
     try {
       const { wcPairingExpiry } = WcController.state;
       const { data: routeData } = RouterController.state;
@@ -73,11 +73,9 @@ export function ConnectingView() {
         }
       });
 
-      const currentRetryTime = retryTimestamp ?? lastRetryRef.current;
-      if (isQr && CoreHelperUtil.isAllowedRetry(currentRetryTime)) {
-        const newRetryTime = Date.now();
-        lastRetryRef.current = newRetryTime;
-        initializeConnection(true, newRetryTime);
+      if (isQr && CoreHelperUtil.isAllowedRetry(lastRetryRef.current)) {
+        lastRetryRef.current = Date.now();
+        initializeConnection(true);
       }
     }
   };
@@ -107,10 +105,7 @@ export function ConnectingView() {
   }, [data, isInstalled]);
 
   useEffect(() => {
-    // Clear any stale URI from previous connection attempts
-    WcController.clearUri();
-
-    initializeConnection();
+    initializeConnection(true);
     let _interval: NodeJS.Timeout;
 
     // Check if the pairing expired every 10 seconds. If expired, it will create a new uri.


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `ConnectingView` component. The change ensures that any stale WalletConnect URI from previous connection attempts is cleared before initializing a new connection, which helps prevent connection issues.

* [`packages/appkit/src/views/w3m-connecting-view/index.tsx`](diffhunk://#diff-b85edf15440f34aec7e1d7d62a97e8cbc3a25f33b793d075ac7103602d36da42R110-R112): Added a call to `WcController.clearUri()` at the start of the `useEffect` to clear stale URIs before initializing a new connection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clears old WalletConnect URI before reconnecting, switches retry timing to a ref, and forces initial reconnect with updated QR auto-retry logic.
> 
> - **ConnectingView (`packages/appkit/src/views/w3m-connecting-view/index.tsx`)**
>   - Clear stale `wc` URI before establishing a new connection on retry or expiry.
>   - Refactor retry timing: replace `lastRetry` state with `useRef`, updating debounce and QR auto-retry logic.
>   - Simplify `initializeConnection` (remove extra arg) and invoke `initializeConnection(true)` on mount; keep periodic pairing-expiry checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cb1e29fc414e1ff38fdcd06a7c72ff7bd077537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->