### PR TITLE
Fix prerelease PR comment and add Slack notifications

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -81,17 +81,46 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Comment Version on Pull Request
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.published != 'true' && steps.changesets.outputs.pullRequestNumber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find PR associated with the current commit
-          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
-            --jq '.[0].number' 2>/dev/null || echo "")
-          
-          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            gh pr comment $PR_NUMBER --body "Published pre-release version: ${{ env.VERSION }}"
-            echo "Commented on PR #$PR_NUMBER"
-          else
-            echo "No associated PR found. This might be a direct push to main."
-          fi
+          gh pr comment ${{ steps.changesets.outputs.pullRequestNumber }} \
+            --body "Published pre-release version: ${{ env.VERSION }}"
+          echo "Commented on PR #${{ steps.changesets.outputs.pullRequestNumber }}"
+
+      - name: Send Slack notification
+        if: steps.changesets.outputs.published != 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "📦 AppKit RN Canary Published",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": "📦 AppKit RN Canary Published" }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Version:*\n`${{ env.VERSION }}`" },
+                    { "type": "mrkdwn", "text": "*Tag:*\n`canary`" },
+                    { "type": "mrkdwn", "text": "*Branch:*\n`${{ github.ref_name }}`" },
+                    { "type": "mrkdwn", "text": "*Triggered by:*\n`${{ github.actor }}`" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": { "type": "mrkdwn", "text": "*NPM:* <https://www.npmjs.com/package/@reown/appkit-react-native/v/${{ env.VERSION }}|@reown/appkit-react-native>" }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    { "type": "mrkdwn", "text": "Install: `yarn add @reown/appkit-react-native@canary`" }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -61,6 +61,7 @@ jobs:
       #     gh release create "v$VERSION" --generate-notes --target main
 
       - name: Publish NPM pre-release
+        id: publish_prerelease
         if: steps.changesets.outputs.published != 'true'
         continue-on-error: true
         env:
@@ -74,23 +75,24 @@ jobs:
           yarn run changeset publish --no-git-tag --snapshot canary --tag canary
 
       - name: Get NPM Version
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.publish_prerelease.outcome == 'success'
         id: get_version
         run: |
           VERSION=$(node -pe "require('./package.json').version")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Comment Version on Pull Request
-        if: steps.changesets.outputs.published != 'true' && steps.changesets.outputs.pullRequestNumber
+        if: steps.publish_prerelease.outcome == 'success' && steps.changesets.outputs.pullRequestNumber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment ${{ steps.changesets.outputs.pullRequestNumber }} \
-            --body "Published pre-release version: ${{ env.VERSION }}"
+            --body "Published pre-release version: ${{ steps.get_version.outputs.VERSION }}"
           echo "Commented on PR #${{ steps.changesets.outputs.pullRequestNumber }}"
 
       - name: Send Slack notification
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.publish_prerelease.outcome == 'success'
+        continue-on-error: true
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -106,7 +108,7 @@ jobs:
                 {
                   "type": "section",
                   "fields": [
-                    { "type": "mrkdwn", "text": "*Version:*\n`${{ env.VERSION }}`" },
+                    { "type": "mrkdwn", "text": "*Version:*\n`${{ steps.get_version.outputs.VERSION }}`" },
                     { "type": "mrkdwn", "text": "*Tag:*\n`canary`" },
                     { "type": "mrkdwn", "text": "*Branch:*\n`${{ github.ref_name }}`" },
                     { "type": "mrkdwn", "text": "*Triggered by:*\n`${{ github.actor }}`" }
@@ -114,7 +116,7 @@ jobs:
                 },
                 {
                   "type": "section",
-                  "text": { "type": "mrkdwn", "text": "*NPM:* <https://www.npmjs.com/package/@reown/appkit-react-native/v/${{ env.VERSION }}|@reown/appkit-react-native>" }
+                  "text": { "type": "mrkdwn", "text": "*NPM:* <https://www.npmjs.com/package/@reown/appkit-react-native/v/${{ steps.get_version.outputs.VERSION }}|@reown/appkit-react-native>" }
                 },
                 {
                   "type": "context",

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Send Slack notification
         if: steps.check-changesets.outputs.has_changesets == 'true'
+        continue-on-error: true
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -92,6 +92,49 @@ jobs:
           yarn run changeset:prepublish:ci
           yarn run changeset publish --no-git-tag --snapshot $snapshot --tag $snapshot
 
+      - name: Get NPM Version
+        if: steps.check-changesets.outputs.has_changesets == 'true'
+        id: get_version
+        run: |
+          VERSION=$(node -pe "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        if: steps.check-changesets.outputs.has_changesets == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "📦 AppKit RN Snapshot Published",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": "📦 AppKit RN Snapshot Published" }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Version:*\n`${{ steps.get_version.outputs.VERSION }}`" },
+                    { "type": "mrkdwn", "text": "*Tag:*\n`${{ steps.determine-tag.outputs.tag }}`" },
+                    { "type": "mrkdwn", "text": "*Branch:*\n`${{ github.ref_name }}`" },
+                    { "type": "mrkdwn", "text": "*Triggered by:*\n`${{ github.actor }}`" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": { "type": "mrkdwn", "text": "*NPM:* <https://www.npmjs.com/package/@reown/appkit-react-native/v/${{ steps.get_version.outputs.VERSION }}|@reown/appkit-react-native>" }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    { "type": "mrkdwn", "text": "Install: `yarn add @reown/appkit-react-native@${{ steps.determine-tag.outputs.tag }}`" }
+                  ]
+                }
+              ]
+            }
+
       - name: Get Snapshot Tag
         id: get-snapshot-tag
         run: |


### PR DESCRIPTION
## Summary

Fixed the CI action that comments pre-release versions on PRs to target the correct PR, and added Slack notifications for both snapshot and canary releases.

**Changes:**
- Fix canary version comment to use `changesets/action`'s `pullRequestNumber` output instead of broken commit API lookup
- Add Slack notifications after snapshot releases (via workflow dispatch) with version, tag, branch, actor, and npm link
- Add Slack notifications after canary releases (main branch) with same details

The notifications include a direct link to the npm package and installation command for easy testing.

## Test plan

- Trigger snapshot workflow on a branch with changesets → verify Slack message with correct version and tag
- Merge a PR to main with a changeset → verify canary Slack message and PR comment on "chore: version packages" PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes affecting release notifications and PR comments; main risk is misconfigured secrets/webhook or conditional logic causing missed/duplicate notifications, not code/runtime behavior.
> 
> **Overview**
> Fixes the canary prerelease workflow to comment on the correct PR by using `changesets/action`’s `pullRequestNumber` output (instead of commit-to-PR API lookup), and gates version extraction/commenting on the prerelease publish step succeeding.
> 
> Adds *best-effort* Slack incoming-webhook notifications after successful canary and snapshot publishes, including the published version, tag, branch, actor, and an npm link/install hint; version is now passed between steps via `$GITHUB_OUTPUT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92fdf6ef3af475441f06c732be8751ef0dc06993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->