### PR TITLE
fix: add content modal wrapper for expo router issues

### DIFF
--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-react-native': patch
+---
+
+feat: add modalWrapper prop for custom modal window wrappers

--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -10,4 +10,4 @@
 '@reown/appkit-wagmi-react-native': patch
 ---
 
-feat: add modalContentWrapper prop for custom modal content wrappers
+fix: add modalContentWrapper prop to work around Expo Router modal layering issues

--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -5,7 +5,6 @@
 '@reown/appkit-core-react-native': patch
 '@reown/appkit-ethers-react-native': patch
 '@reown/appkit-react-native': patch
-'@reown/appkit-react-native-cli': patch
 '@reown/appkit-solana-react-native': patch
 '@reown/appkit-ui-react-native': patch
 '@reown/appkit-wagmi-react-native': patch

--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -1,6 +1,13 @@
 ---
-'@reown/appkit-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
 '@reown/appkit-ethers-react-native': patch
+'@reown/appkit-react-native': patch
+'@reown/appkit-react-native-cli': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
 '@reown/appkit-wagmi-react-native': patch
 ---
 

--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -1,5 +1,7 @@
 ---
 '@reown/appkit-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
 ---
 
 feat: add modalWrapper prop for custom modal window wrappers

--- a/.changeset/sharp-cars-approve.md
+++ b/.changeset/sharp-cars-approve.md
@@ -11,4 +11,4 @@
 '@reown/appkit-wagmi-react-native': patch
 ---
 
-feat: add modalWrapper prop for custom modal window wrappers
+feat: add modalContentWrapper prop for custom modal content wrappers

--- a/examples/expo-multichain/app/_layout.tsx
+++ b/examples/expo-multichain/app/_layout.tsx
@@ -98,7 +98,7 @@ export default function RootLayout() {
             <StatusBar style="auto" />
             {/* Mount AppKit once in the root layout to avoid Android Expo Router modal layering issues.
                 If your app already uses react-native-screens and transparentModal still hides the modal,
-                pass modalWrapper={FullWindowOverlay} here. */}
+                pass modalContentWrapper={FullWindowOverlay} here. */}
             <View style={{ position: 'absolute', height: '100%', width: '100%' }}>
               <AppKit />
             </View>

--- a/examples/expo-multichain/app/_layout.tsx
+++ b/examples/expo-multichain/app/_layout.tsx
@@ -96,7 +96,9 @@ export default function RootLayout() {
               <Stack.Screen name="+not-found" />
             </Stack>
             <StatusBar style="auto" />
-            {/* This is a workaround for the Android modal issue. https://github.com/expo/expo/issues/32991#issuecomment-2489620459 */}
+            {/* Mount AppKit once in the root layout to avoid Android Expo Router modal layering issues.
+                If your app already uses react-native-screens and transparentModal still hides the modal,
+                pass modalWrapper={FullWindowOverlay} here. */}
             <View style={{ position: 'absolute', height: '100%', width: '100%' }}>
               <AppKit />
             </View>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   preset: 'react-native',
   modulePathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib/'],
@@ -8,6 +10,16 @@ module.exports = {
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { configFile: './babel.config.js' }]
   },
   moduleNameMapper: {
-    '^@shared-jest-setup$': '<rootDir>/jest-shared-setup.ts'
+    '^@shared-jest-setup$': '<rootDir>/jest-shared-setup.ts',
+    '^@reown/appkit-react-native$': path.join(__dirname, 'packages/appkit/src/index.ts'),
+    '^@reown/appkit-bitcoin-react-native$': path.join(__dirname, 'packages/bitcoin/src/index.tsx'),
+    '^@reown/appkit-coinbase-react-native$': path.join(__dirname, 'packages/coinbase/src/index.ts'),
+    '^@reown/appkit-common-react-native$': path.join(__dirname, 'packages/common/src/index.ts'),
+    '^@reown/appkit-core-react-native$': path.join(__dirname, 'packages/core/src/index.ts'),
+    '^@reown/appkit-ethers-react-native$': path.join(__dirname, 'packages/ethers/src/index.tsx'),
+    '^@reown/appkit-react-native-cli$': path.join(__dirname, 'packages/cli/src/index.ts'),
+    '^@reown/appkit-solana-react-native$': path.join(__dirname, 'packages/solana/src/index.ts'),
+    '^@reown/appkit-ui-react-native$': path.join(__dirname, 'packages/ui/src/index.ts'),
+    '^@reown/appkit-wagmi-react-native$': path.join(__dirname, 'packages/wagmi/src/index.tsx')
   }
 };

--- a/packages/appkit/jest.config.ts
+++ b/packages/appkit/jest.config.ts
@@ -1,8 +1,10 @@
+const rootConfig = require('../../jest.config');
+
 const appkitConfig = {
-  ...require('../../jest.config'),
+  ...rootConfig,
   setupFilesAfterEnv: ['./jest-setup.ts'],
-  // Override the moduleNameMapper to use the correct path from the package
   moduleNameMapper: {
+    ...rootConfig.moduleNameMapper,
     '^@shared-jest-setup$': '../../jest-shared-setup.ts'
   }
 };

--- a/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
+++ b/packages/appkit/src/__tests__/hooks/useAppKitTheme.test.tsx
@@ -18,16 +18,20 @@ jest.mock('valtio', () => ({
 }));
 
 // Mock ThemeController
-jest.mock('@reown/appkit-core-react-native', () => ({
-  ThemeController: {
-    state: {
-      themeMode: 'light',
-      themeVariables: {}
-    },
-    setDefaultThemeMode: jest.fn(),
-    setThemeVariables: jest.fn()
-  }
-}));
+jest.mock(
+  '@reown/appkit-core-react-native',
+  () => ({
+    ThemeController: {
+      state: {
+        themeMode: 'light',
+        themeVariables: {}
+      },
+      setDefaultThemeMode: jest.fn(),
+      setThemeVariables: jest.fn()
+    }
+  }),
+  { virtual: true }
+);
 
 describe('useAppKitTheme', () => {
   const mockAppKit = {} as AppKit;

--- a/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
+++ b/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
@@ -107,7 +107,7 @@ describe('AppKit modal', () => {
     const { getByTestId, queryByTestId } = render(<AppKit />);
 
     expect(getByTestId('w3m-modal')).toBeTruthy();
-    expect(queryByTestId('modal-wrapper')).toBeNull();
+    expect(queryByTestId('modal-content-wrapper')).toBeNull();
   });
 
   it('wraps modal content when modalContentWrapper is provided', () => {

--- a/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
+++ b/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { View } from 'react-native';
+
+const mockClose = jest.fn();
+const mockPrefetch = jest.fn().mockResolvedValue(undefined);
+const mockSendEvent = jest.fn();
+
+jest.mock('valtio', () => ({
+  useSnapshot: jest.fn((state: Record<string, unknown>) => state)
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: jest.fn(() => ({ top: 0, bottom: 0 }))
+}));
+
+jest.mock('../../AppKitContext', () => ({
+  useInternalAppKit: jest.fn(() => ({
+    close: mockClose
+  }))
+}));
+
+jest.mock('../../partials/w3m-header', () => ({
+  Header: () => 'Header'
+}));
+
+jest.mock('../../partials/w3m-snackbar', () => ({
+  Snackbar: () => 'Snackbar'
+}));
+
+jest.mock('../../modal/w3m-router', () => ({
+  AppKitRouter: () => 'Router'
+}));
+
+jest.mock(
+  '@reown/appkit-ui-react-native',
+  () => {
+    const { View: MockView } = require('react-native');
+
+    return {
+      Card: ({ children, ...props }: any) => (
+        <MockView {...props} testID="mock-card">
+          {children}
+        </MockView>
+      ),
+      Modal: ({ children, testID }: any) => <MockView testID={testID}>{children}</MockView>,
+      ThemeProvider: ({ children }: any) => <>{children}</>
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  '@reown/appkit-core-react-native',
+  () => ({
+    ApiController: {
+      prefetch: mockPrefetch
+    },
+    EventsController: {
+      sendEvent: mockSendEvent
+    },
+    ModalController: {
+      state: {
+        open: true
+      }
+    },
+    OptionsController: {
+      state: {
+        projectId: 'project-id'
+      }
+    },
+    RouterController: {
+      state: {
+        history: ['Connect']
+      },
+      goBack: jest.fn()
+    },
+    ThemeController: {
+      state: {
+        themeMode: 'light',
+        themeVariables: {}
+      },
+      setSystemThemeMode: jest.fn()
+    }
+  }),
+  { virtual: true }
+);
+
+const { AppKit } = require('../../modal/w3m-modal');
+
+describe('AppKit modal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the modal without a wrapper', () => {
+    const { getByTestId, queryByTestId } = render(<AppKit />);
+
+    expect(getByTestId('w3m-modal')).toBeTruthy();
+    expect(queryByTestId('modal-wrapper')).toBeNull();
+  });
+
+  it('wraps the modal when modalWrapper is provided', () => {
+    function ModalWrapper({ children }: { children: React.ReactNode }) {
+      return <View testID="modal-wrapper">{children}</View>;
+    }
+
+    const { getByTestId } = render(<AppKit modalWrapper={ModalWrapper} />);
+
+    expect(getByTestId('modal-wrapper')).toBeTruthy();
+    expect(getByTestId('w3m-modal')).toBeTruthy();
+  });
+});

--- a/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
+++ b/packages/appkit/src/__tests__/modal/w3m-modal.test.tsx
@@ -5,6 +5,9 @@ import { View } from 'react-native';
 const mockClose = jest.fn();
 const mockPrefetch = jest.fn().mockResolvedValue(undefined);
 const mockSendEvent = jest.fn();
+const modalState = {
+  open: true
+};
 
 jest.mock('valtio', () => ({
   useSnapshot: jest.fn((state: Record<string, unknown>) => state)
@@ -43,7 +46,15 @@ jest.mock(
           {children}
         </MockView>
       ),
-      Modal: ({ children, testID }: any) => <MockView testID={testID}>{children}</MockView>,
+      Modal: ({ children, testID, visible, contentWrapper: ContentWrapper }: any) => {
+        if (!visible) {
+          return null;
+        }
+
+        const content = ContentWrapper ? <ContentWrapper>{children}</ContentWrapper> : children;
+
+        return <MockView testID={testID}>{content}</MockView>;
+      },
       ThemeProvider: ({ children }: any) => <>{children}</>
     };
   },
@@ -60,9 +71,7 @@ jest.mock(
       sendEvent: mockSendEvent
     },
     ModalController: {
-      state: {
-        open: true
-      }
+      state: modalState
     },
     OptionsController: {
       state: {
@@ -91,6 +100,7 @@ const { AppKit } = require('../../modal/w3m-modal');
 describe('AppKit modal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    modalState.open = true;
   });
 
   it('renders the modal without a wrapper', () => {
@@ -100,14 +110,23 @@ describe('AppKit modal', () => {
     expect(queryByTestId('modal-wrapper')).toBeNull();
   });
 
-  it('wraps the modal when modalWrapper is provided', () => {
-    function ModalWrapper({ children }: { children: React.ReactNode }) {
-      return <View testID="modal-wrapper">{children}</View>;
+  it('wraps modal content when modalContentWrapper is provided', () => {
+    function ModalContentWrapper({ children }: { children: React.ReactNode }) {
+      return <View testID="modal-content-wrapper">{children}</View>;
     }
 
-    const { getByTestId } = render(<AppKit modalWrapper={ModalWrapper} />);
+    const { getByTestId } = render(<AppKit modalContentWrapper={ModalContentWrapper} />);
 
-    expect(getByTestId('modal-wrapper')).toBeTruthy();
+    expect(getByTestId('modal-content-wrapper')).toBeTruthy();
     expect(getByTestId('w3m-modal')).toBeTruthy();
+  });
+
+  it('does not render modal content when closed', () => {
+    modalState.open = false;
+
+    const { queryByTestId } = render(<AppKit />);
+
+    expect(queryByTestId('w3m-modal')).toBeNull();
+    expect(queryByTestId('mock-card')).toBeNull();
   });
 });

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -17,8 +17,8 @@ export {
 export {
   AppKit,
   type AppKitProps,
-  type AppKitModalWrapperComponent,
-  type AppKitModalWrapperProps
+  type AppKitModalContentWrapperComponent,
+  type AppKitModalContentWrapperProps
 } from './modal/w3m-modal';
 
 /********** Types **********/

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -14,7 +14,12 @@ export {
   NetworkButton as NetworkButton,
   type NetworkButtonProps as NetworkButtonProps
 } from './modal/w3m-network-button';
-export { AppKit } from './modal/w3m-modal';
+export {
+  AppKit,
+  type AppKitProps,
+  type AppKitModalWrapperComponent,
+  type AppKitModalWrapperProps
+} from './modal/w3m-modal';
 
 /********** Types **********/
 export type * from '@reown/appkit-core-react-native';

--- a/packages/appkit/src/modal/w3m-modal/index.tsx
+++ b/packages/appkit/src/modal/w3m-modal/index.tsx
@@ -1,5 +1,5 @@
 import { useSnapshot } from 'valtio';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, type ComponentType, type ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
 import { Card, Modal, ThemeProvider } from '@reown/appkit-ui-react-native';
 import {
@@ -18,7 +18,17 @@ import { Snackbar } from '../../partials/w3m-snackbar';
 import { useInternalAppKit } from '../../AppKitContext';
 import styles from './styles';
 
-export function AppKit() {
+export interface AppKitModalWrapperProps {
+  children: ReactNode;
+}
+
+export type AppKitModalWrapperComponent = ComponentType<AppKitModalWrapperProps>;
+
+export interface AppKitProps {
+  modalWrapper?: AppKitModalWrapperComponent;
+}
+
+export function AppKit({ modalWrapper: ModalWrapper }: AppKitProps) {
   const theme = useColorScheme();
   const { bottom, top } = useSafeAreaInsets();
   const { close } = useInternalAppKit();
@@ -53,20 +63,24 @@ export function AppKit() {
     }
   }, [projectId, prefetch]);
 
+  const modal = (
+    <Modal
+      visible={open}
+      onRequestClose={handleBackPress}
+      onBackdropPress={handleModalClose}
+      testID="w3m-modal"
+    >
+      <Card style={[styles.card, { paddingBottom: bottom, marginTop: top }]}>
+        <Header />
+        <AppKitRouter />
+        <Snackbar />
+      </Card>
+    </Modal>
+  );
+
   return (
     <ThemeProvider themeMode={themeMode} themeVariables={themeVariables}>
-      <Modal
-        visible={open}
-        onRequestClose={handleBackPress}
-        onBackdropPress={handleModalClose}
-        testID="w3m-modal"
-      >
-        <Card style={[styles.card, { paddingBottom: bottom, marginTop: top }]}>
-          <Header />
-          <AppKitRouter />
-          <Snackbar />
-        </Card>
-      </Modal>
+      {ModalWrapper ? <ModalWrapper>{modal}</ModalWrapper> : modal}
     </ThemeProvider>
   );
 }

--- a/packages/appkit/src/modal/w3m-modal/index.tsx
+++ b/packages/appkit/src/modal/w3m-modal/index.tsx
@@ -18,17 +18,17 @@ import { Snackbar } from '../../partials/w3m-snackbar';
 import { useInternalAppKit } from '../../AppKitContext';
 import styles from './styles';
 
-export interface AppKitModalWrapperProps {
+export interface AppKitModalContentWrapperProps {
   children: ReactNode;
 }
 
-export type AppKitModalWrapperComponent = ComponentType<AppKitModalWrapperProps>;
+export type AppKitModalContentWrapperComponent = ComponentType<AppKitModalContentWrapperProps>;
 
 export interface AppKitProps {
-  modalWrapper?: AppKitModalWrapperComponent;
+  modalContentWrapper?: AppKitModalContentWrapperComponent;
 }
 
-export function AppKit({ modalWrapper: ModalWrapper }: AppKitProps) {
+export function AppKit({ modalContentWrapper }: AppKitProps) {
   const theme = useColorScheme();
   const { bottom, top } = useSafeAreaInsets();
   const { close } = useInternalAppKit();
@@ -63,24 +63,21 @@ export function AppKit({ modalWrapper: ModalWrapper }: AppKitProps) {
     }
   }, [projectId, prefetch]);
 
-  const modal = (
-    <Modal
-      visible={open}
-      onRequestClose={handleBackPress}
-      onBackdropPress={handleModalClose}
-      testID="w3m-modal"
-    >
-      <Card style={[styles.card, { paddingBottom: bottom, marginTop: top }]}>
-        <Header />
-        <AppKitRouter />
-        <Snackbar />
-      </Card>
-    </Modal>
-  );
-
   return (
     <ThemeProvider themeMode={themeMode} themeVariables={themeVariables}>
-      {ModalWrapper ? <ModalWrapper>{modal}</ModalWrapper> : modal}
+      <Modal
+        visible={open}
+        onRequestClose={handleBackPress}
+        onBackdropPress={handleModalClose}
+        testID="w3m-modal"
+        contentWrapper={modalContentWrapper}
+      >
+        <Card style={[styles.card, { paddingBottom: bottom, marginTop: top }]}>
+          <Header />
+          <AppKitRouter />
+          <Snackbar />
+        </Card>
+      </Modal>
     </ThemeProvider>
   );
 }

--- a/packages/common/jest.config.ts
+++ b/packages/common/jest.config.ts
@@ -1,8 +1,10 @@
+const rootConfig = require('../../jest.config');
+
 const commonConfig = {
-  ...require('../../jest.config'),
+  ...rootConfig,
   setupFilesAfterEnv: ['./jest-setup.ts'],
-  // Override the moduleNameMapper to use the correct path from the package
   moduleNameMapper: {
+    ...rootConfig.moduleNameMapper,
     '^@shared-jest-setup$': '../../jest-shared-setup.ts'
   }
 };

--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -1,8 +1,10 @@
+const rootConfig = require('../../jest.config');
+
 const coreConfig = {
-  ...require('../../jest.config'),
+  ...rootConfig,
   setupFilesAfterEnv: ['./jest-setup.ts'],
-  // Override the moduleNameMapper to use the correct path from the package
   moduleNameMapper: {
+    ...rootConfig.moduleNameMapper,
     '^@shared-jest-setup$': '../../jest-shared-setup.ts'
   }
 };

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -1,8 +1,10 @@
+const rootConfig = require('../../jest.config');
+
 const uiConfig = {
-  ...require('../../jest.config'),
+  ...rootConfig,
   setupFilesAfterEnv: ['./jest-setup.ts'],
-  // Override the moduleNameMapper to use the correct path from the package
   moduleNameMapper: {
+    ...rootConfig.moduleNameMapper,
     '^@shared-jest-setup$': '../../jest-shared-setup.ts'
   }
 };

--- a/packages/ui/src/components/wui-modal/index.tsx
+++ b/packages/ui/src/components/wui-modal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ComponentType, type ReactNode } from 'react';
 import {
   useWindowDimensions,
   Modal as RNModal,
@@ -14,13 +14,27 @@ export type ModalProps = Pick<
   RNModalProps,
   'visible' | 'onDismiss' | 'testID' | 'onRequestClose'
 > & {
-  children: React.ReactNode;
+  children: ReactNode;
   onBackdropPress?: () => void;
+  contentWrapper?: ModalContentWrapperComponent;
 };
+
+export interface ModalContentWrapperProps {
+  children: ReactNode;
+}
+
+export type ModalContentWrapperComponent = ComponentType<ModalContentWrapperProps>;
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-export function Modal({ visible, onBackdropPress, onRequestClose, testID, children }: ModalProps) {
+export function Modal({
+  visible,
+  onBackdropPress,
+  onRequestClose,
+  testID,
+  children,
+  contentWrapper: ContentWrapper
+}: ModalProps) {
   const { height } = useWindowDimensions();
   const Theme = useTheme();
   const backdropOpacity = useRef(new Animated.Value(0)).current;
@@ -120,16 +134,35 @@ export function Modal({ visible, onBackdropPress, onRequestClose, testID, childr
       onRequestClose={onRequestClose}
       testID={testID}
     >
-      {showBackdrop ? (
-        <AnimatedPressable
-          style={[styles.backdrop, { opacity: backdropOpacity }]}
-          onPress={onBackdropPress}
-        />
-      ) : null}
-      <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
-        <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
-        <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
-      </Animated.View>
+      {ContentWrapper ? (
+        <ContentWrapper>
+          <>
+            {showBackdrop ? (
+              <AnimatedPressable
+                style={[styles.backdrop, { opacity: backdropOpacity }]}
+                onPress={onBackdropPress}
+              />
+            ) : null}
+            <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
+              <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
+              <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
+            </Animated.View>
+          </>
+        </ContentWrapper>
+      ) : (
+        <>
+          {showBackdrop ? (
+            <AnimatedPressable
+              style={[styles.backdrop, { opacity: backdropOpacity }]}
+              onPress={onBackdropPress}
+            />
+          ) : null}
+          <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
+            <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
+            <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
+          </Animated.View>
+        </>
+      )}
     </RNModal>
   );
 }

--- a/packages/ui/src/components/wui-modal/index.tsx
+++ b/packages/ui/src/components/wui-modal/index.tsx
@@ -125,6 +125,21 @@ export function Modal({
     }
   }, [modalVisible, translateY, backdropOpacity, height]);
 
+  const modalContent = (
+    <>
+      {showBackdrop ? (
+        <AnimatedPressable
+          style={[styles.backdrop, { opacity: backdropOpacity }]}
+          onPress={onBackdropPress}
+        />
+      ) : null}
+      <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
+        <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
+        <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
+      </Animated.View>
+    </>
+  );
+
   return (
     <RNModal
       visible={modalVisible}
@@ -134,35 +149,7 @@ export function Modal({
       onRequestClose={onRequestClose}
       testID={testID}
     >
-      {ContentWrapper ? (
-        <ContentWrapper>
-          <>
-            {showBackdrop ? (
-              <AnimatedPressable
-                style={[styles.backdrop, { opacity: backdropOpacity }]}
-                onPress={onBackdropPress}
-              />
-            ) : null}
-            <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
-              <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
-              <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
-            </Animated.View>
-          </>
-        </ContentWrapper>
-      ) : (
-        <>
-          {showBackdrop ? (
-            <AnimatedPressable
-              style={[styles.backdrop, { opacity: backdropOpacity }]}
-              onPress={onBackdropPress}
-            />
-          ) : null}
-          <Animated.View style={[styles.modal, { transform: [{ translateY }] }]}>
-            <Animated.View onLayout={onContentLayout}>{children}</Animated.View>
-            <View style={[styles.bottomBackground, { backgroundColor: Theme['bg-100'] }]} />
-          </Animated.View>
-        </>
-      )}
+      {ContentWrapper ? <ContentWrapper>{modalContent}</ContentWrapper> : modalContent}
     </RNModal>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,7 +50,12 @@ export { ListTransaction, type ListTransactionProps } from './composites/wui-lis
 export { ListWallet, type ListWalletProps } from './composites/wui-list-wallet';
 export { Logo, type LogoProps } from './composites/wui-logo';
 export { LogoSelect, type LogoSelectProps } from './composites/wui-logo-select';
-export { Modal, type ModalProps } from './components/wui-modal';
+export {
+  Modal,
+  type ModalContentWrapperComponent,
+  type ModalContentWrapperProps,
+  type ModalProps
+} from './components/wui-modal';
 export { NetworkButton, type NetworkButtonProps } from './composites/wui-network-button';
 export { NetworkImage, type NetworkImageProps } from './composites/wui-network-image';
 export { NumericKeyboard, type NumericKeyboardProps } from './composites/wui-numeric-keyboard';


### PR DESCRIPTION
## Summary
- add an optional `contentModalWrapper` prop to `AppKit` so apps can wrap the internal RN modal content with a custom window overlay such as `FullWindowOverlay`
- add regression coverage for the wrapped and unwrapped AppKit modal paths
- fix Jest workspace module resolution so package tests resolve internal `@reown/appkit-*` imports from `src` during tests

## Testing
- yarn format
- yarn lint
- yarn test
