### PR TITLE
chore: bump claude auto review version

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Auto Review
-        uses: WalletConnect/actions/claude/auto-review@1483e05460107d74c575e31af948ce20f9df6387
+        uses: WalletConnect/actions/claude/auto-review@abf509235bc59f907de7905071c6910a0ac5de94
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-sonnet-4-6

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -31,7 +31,6 @@ jobs:
         uses: WalletConnect/actions/claude/auto-review@abf509235bc59f907de7905071c6910a0ac5de94
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-6
           timeout_minutes: "60"
           project_context: |
             This is the AppKit React Native SDK, a comprehensive wallet connection and blockchain interaction library for React Native applications.


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Claude Auto Review by changing the referenced action version to a newer commit. This ensures that the workflow uses the latest improvements or bug fixes from the `WalletConnect/actions/claude/auto-review` action.

Workflow update:

* Updated the `Claude Auto Review` step in `.github/workflows/claude-auto-review.yml` to use action version `abf509235bc59f907de7905071c6910a0ac5de94` instead of `1483e05460107d74c575e31af948ce20f9df6387`.
* Removed `model` param to use the default one