### PR TITLE
Add WalletConnect logger option

### DIFF
--- a/.changeset/walletconnect-logger-option.md
+++ b/.changeset/walletconnect-logger-option.md
@@ -9,4 +9,4 @@
 '@reown/appkit-wagmi-react-native': patch
 ---
 
-feat: add `logger` option to `createAppKit` for controlling `@walletconnect/universal-provider` log output. Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`) or a custom pino-compatible `Logger` instance. When omitted, WalletConnect's default logging is preserved.
+feat: add `logger` option to `createAppKit` for controlling `@walletconnect/universal-provider` log output. Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`). When omitted, WalletConnect's default logging is preserved.

--- a/.changeset/walletconnect-logger-option.md
+++ b/.changeset/walletconnect-logger-option.md
@@ -1,0 +1,12 @@
+---
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+feat: add `logger` option to `createAppKit` for controlling `@walletconnect/universal-provider` log output. Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`) or a custom pino-compatible `Logger` instance. When omitted, WalletConnect's default logging is preserved.

--- a/.changeset/walletconnect-logger-option.md
+++ b/.changeset/walletconnect-logger-option.md
@@ -1,4 +1,5 @@
 ---
+'@reown/appkit-react-native': patch
 '@reown/appkit-bitcoin-react-native': patch
 '@reown/appkit-coinbase-react-native': patch
 '@reown/appkit-common-react-native': patch
@@ -9,4 +10,4 @@
 '@reown/appkit-wagmi-react-native': patch
 ---
 
-feat: add `logger` option to `createAppKit` for controlling `@walletconnect/universal-provider` log output. Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`). When omitted, WalletConnect's default logging is preserved.
+feat: add `logger` option to `createAppKit` for controlling `@walletconnect/universal-provider` log output. Accepts a log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`). When omitted, WalletConnect's default logging is preserved.

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -393,7 +393,8 @@ export class AppKit {
     if (CustomConnector) {
       await CustomConnector.init({
         storage: this.config.storage,
-        metadata: this.config.metadata
+        metadata: this.config.metadata,
+        logger: this.config.logger
       });
 
       return CustomConnector;
@@ -413,7 +414,8 @@ export class AppKit {
     });
     await this.walletConnectConnector.init({
       storage: this.config.storage,
-      metadata: this.config.metadata
+      metadata: this.config.metadata,
+      logger: this.config.logger
     });
 
     return this.walletConnectConnector;

--- a/packages/appkit/src/connectors/WalletConnectConnector.ts
+++ b/packages/appkit/src/connectors/WalletConnectConnector.ts
@@ -30,12 +30,11 @@ export class WalletConnectConnector extends WalletConnector {
 
   override async init(ops: ConnectorInitOptions) {
     super.init(ops);
-    const logger = typeof ops.logger === 'string' ? ops.logger : undefined;
 
     const provider = await this.getUniversalProvider({
       projectId: this.config.projectId,
       metadata: ops.metadata,
-      logger
+      logger: ops.logger
     });
 
     this.provider = provider as Provider;
@@ -90,7 +89,7 @@ export class WalletConnectConnector extends WalletConnector {
   }: {
     projectId: string;
     metadata: Metadata;
-    logger?: string;
+    logger?: ConnectorInitOptions['logger'];
   }): Promise<UniversalProvider> {
     if (!this.provider) {
       this.provider = (await UniversalProvider.init({

--- a/packages/appkit/src/connectors/WalletConnectConnector.ts
+++ b/packages/appkit/src/connectors/WalletConnectConnector.ts
@@ -1,5 +1,5 @@
 import { WcController } from '@reown/appkit-core-react-native';
-import UniversalProvider from '@walletconnect/universal-provider';
+import UniversalProvider, { type UniversalProviderOpts } from '@walletconnect/universal-provider';
 import {
   WalletConnector,
   type AppKitNetwork,
@@ -33,7 +33,8 @@ export class WalletConnectConnector extends WalletConnector {
 
     const provider = await this.getUniversalProvider({
       projectId: this.config.projectId,
-      metadata: ops.metadata
+      metadata: ops.metadata,
+      logger: ops.logger as UniversalProviderOpts['logger']
     });
 
     this.provider = provider as Provider;
@@ -83,16 +84,19 @@ export class WalletConnectConnector extends WalletConnector {
 
   private async getUniversalProvider({
     projectId,
-    metadata
+    metadata,
+    logger
   }: {
     projectId: string;
     metadata: Metadata;
+    logger?: UniversalProviderOpts['logger'];
   }): Promise<UniversalProvider> {
     if (!this.provider) {
       this.provider = (await UniversalProvider.init({
         projectId,
         metadata,
-        storage: this.storage
+        storage: this.storage,
+        ...(logger !== undefined && { logger })
       })) as Provider;
     }
 

--- a/packages/appkit/src/connectors/WalletConnectConnector.ts
+++ b/packages/appkit/src/connectors/WalletConnectConnector.ts
@@ -1,5 +1,5 @@
 import { WcController } from '@reown/appkit-core-react-native';
-import UniversalProvider, { type UniversalProviderOpts } from '@walletconnect/universal-provider';
+import UniversalProvider from '@walletconnect/universal-provider';
 import {
   WalletConnector,
   type AppKitNetwork,
@@ -30,11 +30,12 @@ export class WalletConnectConnector extends WalletConnector {
 
   override async init(ops: ConnectorInitOptions) {
     super.init(ops);
+    const logger = typeof ops.logger === 'string' ? ops.logger : undefined;
 
     const provider = await this.getUniversalProvider({
       projectId: this.config.projectId,
       metadata: ops.metadata,
-      logger: ops.logger as UniversalProviderOpts['logger']
+      logger
     });
 
     this.provider = provider as Provider;
@@ -89,7 +90,7 @@ export class WalletConnectConnector extends WalletConnector {
   }: {
     projectId: string;
     metadata: Metadata;
-    logger?: UniversalProviderOpts['logger'];
+    logger?: string;
   }): Promise<UniversalProvider> {
     if (!this.provider) {
       this.provider = (await UniversalProvider.init({

--- a/packages/appkit/src/types.ts
+++ b/packages/appkit/src/types.ts
@@ -3,6 +3,7 @@ import {
   type Features,
   type UniversalProviderConfigOverride,
   type WalletConnector,
+  type ConnectorInitOptions,
   type BlockchainAdapter,
   type Metadata,
   type Network,
@@ -12,18 +13,6 @@ import {
   type Tokens,
   type SIWXConfig
 } from '@reown/appkit-common-react-native';
-
-type WalletConnectLoggerLevel = 'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
-
-type WalletConnectLogger = {
-  child(bindings: Record<string, unknown>): WalletConnectLogger;
-  trace: (...args: unknown[]) => void;
-  debug: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-  fatal: (...args: unknown[]) => void;
-};
 
 /**
  * Configuration interface for initializing the AppKit instance.
@@ -150,13 +139,12 @@ export interface AppKitConfig {
 
   /**
    * Optional logger configuration forwarded to `@walletconnect/universal-provider`.
-   * Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`)
-   * or a custom pino-compatible `Logger` instance. When omitted, WalletConnect's
-   * default logging is used.
+   * Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`).
+   * When omitted, WalletConnect's default logging is used.
    *
    * @example logger: 'silent'
    */
-  logger?: WalletConnectLoggerLevel | WalletConnectLogger;
+  logger?: ConnectorInitOptions['logger'];
 
   /**
    * Optional theme mode for the AppKit UI.

--- a/packages/appkit/src/types.ts
+++ b/packages/appkit/src/types.ts
@@ -139,7 +139,7 @@ export interface AppKitConfig {
 
   /**
    * Optional logger configuration forwarded to `@walletconnect/universal-provider`.
-   * Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`).
+   * Accepts a log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`).
    * When omitted, WalletConnect's default logging is used.
    *
    * @example logger: 'silent'

--- a/packages/appkit/src/types.ts
+++ b/packages/appkit/src/types.ts
@@ -13,6 +13,18 @@ import {
   type SIWXConfig
 } from '@reown/appkit-common-react-native';
 
+type WalletConnectLoggerLevel = 'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+type WalletConnectLogger = {
+  child(bindings: Record<string, unknown>): WalletConnectLogger;
+  trace: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  fatal: (...args: unknown[]) => void;
+};
+
 /**
  * Configuration interface for initializing the AppKit instance.
  * This interface defines all the required and optional parameters needed to set up
@@ -135,6 +147,16 @@ export interface AppKitConfig {
    * @default false
    */
   debug?: OptionsControllerState['debug'];
+
+  /**
+   * Optional logger configuration forwarded to `@walletconnect/universal-provider`.
+   * Accepts a pino log level (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`)
+   * or a custom pino-compatible `Logger` instance. When omitted, WalletConnect's
+   * default logging is used.
+   *
+   * @example logger: 'silent'
+   */
+  logger?: WalletConnectLoggerLevel | WalletConnectLogger;
 
   /**
    * Optional theme mode for the AppKit UI.

--- a/packages/common/src/types/wallet/connector.ts
+++ b/packages/common/src/types/wallet/connector.ts
@@ -41,21 +41,10 @@ export type WalletConnectLoggerLevel =
   | 'debug'
   | 'trace';
 
-// Structural subset of the pino-compatible logger WalletConnect expects.
-export type WalletConnectLogger = {
-  child(bindings: Record<string, unknown>): WalletConnectLogger;
-  trace: (...args: unknown[]) => void;
-  debug: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-  fatal: (...args: unknown[]) => void;
-};
-
 export type ConnectorInitOptions = {
   storage: Storage;
   metadata: Metadata;
-  logger?: WalletConnectLoggerLevel | WalletConnectLogger;
+  logger?: WalletConnectLoggerLevel;
 };
 
 export abstract class WalletConnector extends EventEmitter {

--- a/packages/common/src/types/wallet/connector.ts
+++ b/packages/common/src/types/wallet/connector.ts
@@ -32,9 +32,30 @@ export type ConnectOptions = {
   universalLink?: string;
 };
 
+export type WalletConnectLoggerLevel =
+  | 'silent'
+  | 'fatal'
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'debug'
+  | 'trace';
+
+// Structural subset of the pino-compatible logger WalletConnect expects.
+export type WalletConnectLogger = {
+  child(bindings: Record<string, unknown>): WalletConnectLogger;
+  trace: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  fatal: (...args: unknown[]) => void;
+};
+
 export type ConnectorInitOptions = {
   storage: Storage;
   metadata: Metadata;
+  logger?: WalletConnectLoggerLevel | WalletConnectLogger;
 };
 
 export abstract class WalletConnector extends EventEmitter {


### PR DESCRIPTION
This adds a `logger` option to `createAppKit` and forwards it through connector initialization into `@walletconnect/universal-provider`, with a changeset for the release.
The public types now accept WalletConnect logger levels including `fatal`, so consumers can disable or tune WalletConnect core logs without passing invalid values.
This gives SDK integrators explicit control over WalletConnect logging while preserving the default behavior when `logger` is omitted.
Validation: `yarn format`, `yarn lint`, and `yarn test`.
