### PR TITLE
chore: pin peer dependency version ranges

### DIFF
--- a/.changeset/cuddly-heads-type.md
+++ b/.changeset/cuddly-heads-type.md
@@ -1,0 +1,13 @@
+---
+'@reown/appkit-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+---
+
+chore: pin peer dependency version ranges

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-test-renderer": "18.3.1",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "tsconfig": "*",
+    "tsconfig": "7.0.0",
     "turbo": "2.5.5",
     "typescript": "5.2.2",
     "viem": "2.31.3",

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -43,11 +43,11 @@
     "@reown/appkit-react-native": "2.0.4"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "*",
+    "@react-native-community/netinfo": ">=11.0.0",
     "@walletconnect/react-native-compat": ">=2.16.1",
     "react": ">=18",
     "react-native": ">=0.72",
-    "react-native-get-random-values": "*"
+    "react-native-get-random-values": ">=1.11.0"
   },
   "react-native": "src/index.tsx"
 }

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -45,11 +45,11 @@
     "@reown/appkit-react-native": "2.0.4"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "*",
+    "@react-native-community/netinfo": ">=11.0.0",
     "@walletconnect/react-native-compat": ">=2.16.1",
     "react": ">=18",
     "react-native": ">=0.72",
-    "react-native-get-random-values": "*",
+    "react-native-get-random-values": ">=1.11.0",
     "viem": ">=2 <3.0.0",
     "wagmi": ">=2 <3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4321,11 +4321,11 @@ __metadata:
     "@reown/appkit-common-react-native": 2.0.4
     "@reown/appkit-react-native": 2.0.4
   peerDependencies:
-    "@react-native-community/netinfo": "*"
+    "@react-native-community/netinfo": ">=11.0.0"
     "@walletconnect/react-native-compat": ">=2.16.1"
     react: ">=18"
     react-native: ">=0.72"
-    react-native-get-random-values: "*"
+    react-native-get-random-values: ">=1.11.0"
   languageName: unknown
   linkType: soft
 
@@ -4453,11 +4453,11 @@ __metadata:
     "@reown/appkit-common-react-native": 2.0.4
     "@reown/appkit-react-native": 2.0.4
   peerDependencies:
-    "@react-native-community/netinfo": "*"
+    "@react-native-community/netinfo": ">=11.0.0"
     "@walletconnect/react-native-compat": ">=2.16.1"
     react: ">=18"
     react-native: ">=0.72"
-    react-native-get-random-values: "*"
+    react-native-get-random-values: ">=1.11.0"
     viem: ">=2 <3.0.0"
     wagmi: ">=2 <3.0.0"
   languageName: unknown
@@ -7014,7 +7014,7 @@ __metadata:
     react-test-renderer: 18.3.1
     ts-jest: 29.1.1
     ts-node: 10.9.1
-    tsconfig: "*"
+    tsconfig: 7.0.0
     turbo: 2.5.5
     typescript: 5.2.2
     viem: 2.31.3
@@ -18280,7 +18280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig@npm:*":
+"tsconfig@npm:7.0.0":
   version: 7.0.0
   resolution: "tsconfig@npm:7.0.0"
   dependencies:


### PR DESCRIPTION
## Summary

Removes `*` wildcards from published package metadata so consumers installing the SDK via npm get bounded, predictable version ranges instead of "any version ever published."

### Changes
- **`packages/ethers` & `packages/wagmi`** — peerDependencies `@react-native-community/netinfo` and `react-native-get-random-values` changed from `*` to `>=11.0.0` and `>=1.11.0` respectively (floors match the versions this repo builds/tests against; consistent with the existing `>=` peer-dep convention).
- **root `package.json`** — `tsconfig` devDependency pinned from `*` to `7.0.0` (latest; same version that was already resolving). Not published, but removes the only remaining wildcard in the repo's own install.
- `yarn.lock` synced.

All regular `dependencies` in the published packages were already exact-pinned — no change needed there.

### Notes
- peerDependencies aren't installed into the SDK's own tree; they're declared for the host app. The benefit here is bounded metadata + a sane floor for npm 7+'s peer auto-install, rather than changing what the SDK itself pulls in.
- Changeset bumps all 9 packages (patch) to keep versions aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)