### PR TITLE
fix(core): load wallet & network images on React Native

### DIFF
--- a/.changeset/fix-fetch-image-blob-arraybuffer.md
+++ b/.changeset/fix-fetch-image-blob-arraybuffer.md
@@ -1,0 +1,12 @@
+---
+'@reown/appkit-core-react-native': patch
+---
+
+fix(core): load wallet & network images on React Native
+
+`FetchUtil.fetchImage` built its data URL with `response.blob()` + `FileReader`,
+but on React Native `fetch(...).blob()` throws "Creating blobs from 'ArrayBuffer'
+and 'ArrayBufferView' are not supported" for binary responses — so wallet and
+network images silently failed to load (placeholders only). Read the bytes via
+`response.arrayBuffer()` and base64-encode them into the data URL instead, using
+a dependency-free encoder (RN guarantees neither `Buffer` nor `btoa`).

--- a/.changeset/fix-fetch-image-blob-arraybuffer.md
+++ b/.changeset/fix-fetch-image-blob-arraybuffer.md
@@ -1,5 +1,13 @@
 ---
+'@reown/appkit-react-native': patch
+'@reown/appkit-bitcoin-react-native': patch
+'@reown/appkit-coinbase-react-native': patch
+'@reown/appkit-common-react-native': patch
 '@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-solana-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
 ---
 
 fix(core): load wallet & network images on React Native

--- a/packages/core/src/__tests__/utils/FetchUtil.test.ts
+++ b/packages/core/src/__tests__/utils/FetchUtil.test.ts
@@ -104,4 +104,61 @@ describe('FetchUtil', () => {
       expect(url).toBe('https://another.com/test?foo=bar&bar=baz&clientId=test-client-id');
     });
   });
+
+  describe('fetchImage', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should build a base64 data URL from the response ArrayBuffer', async () => {
+      // "foobar" -> base64 "Zm9vYmFy"
+      const bytes = new Uint8Array([0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+      global.fetch = jest.fn().mockResolvedValue({
+        arrayBuffer: async () => bytes.buffer,
+        headers: { get: () => 'image/png' }
+      }) as unknown as typeof fetch;
+
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const result = await fetchUtil.fetchImage('/getWalletImage/1');
+
+      expect(result).toBe('data:image/png;base64,Zm9vYmFy');
+    });
+
+    it('should default the content type to image/png when the header is missing', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        arrayBuffer: async () => new Uint8Array([0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]).buffer,
+        headers: { get: () => null }
+      }) as unknown as typeof fetch;
+
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const result = await fetchUtil.fetchImage('/getWalletImage/1');
+
+      expect(result).toBe('data:image/png;base64,Zm9vYmFy');
+    });
+
+    it('should not call response.blob() (RN cannot build a Blob from an ArrayBuffer)', async () => {
+      const blob = jest.fn();
+      global.fetch = jest.fn().mockResolvedValue({
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        headers: { get: () => 'image/webp' },
+        blob
+      }) as unknown as typeof fetch;
+
+      const fetchUtil = new FetchUtil({ baseUrl });
+      await fetchUtil.fetchImage('/getWalletImage/1');
+
+      expect(blob).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined when the request throws', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const result = await fetchUtil.fetchImage('/getWalletImage/1');
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/__tests__/utils/FetchUtil.test.ts
+++ b/packages/core/src/__tests__/utils/FetchUtil.test.ts
@@ -116,6 +116,7 @@ describe('FetchUtil', () => {
       // "foobar" -> base64 "Zm9vYmFy"
       const bytes = new Uint8Array([0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
       global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
         arrayBuffer: async () => bytes.buffer,
         headers: { get: () => 'image/png' }
       }) as unknown as typeof fetch;
@@ -126,8 +127,24 @@ describe('FetchUtil', () => {
       expect(result).toBe('data:image/png;base64,Zm9vYmFy');
     });
 
+    it('should return undefined for a non-ok response', async () => {
+      const arrayBuffer = jest.fn();
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        arrayBuffer,
+        headers: { get: () => 'application/json' }
+      }) as unknown as typeof fetch;
+
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const result = await fetchUtil.fetchImage('/getWalletImage/1');
+
+      expect(result).toBeUndefined();
+      expect(arrayBuffer).not.toHaveBeenCalled();
+    });
+
     it('should default the content type to image/png when the header is missing', async () => {
       global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
         arrayBuffer: async () => new Uint8Array([0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]).buffer,
         headers: { get: () => null }
       }) as unknown as typeof fetch;
@@ -141,6 +158,7 @@ describe('FetchUtil', () => {
     it('should not call response.blob() (RN cannot build a Blob from an ArrayBuffer)', async () => {
       const blob = jest.fn();
       global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
         arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
         headers: { get: () => 'image/webp' },
         blob

--- a/packages/core/src/__tests__/utils/FetchUtil.test.ts
+++ b/packages/core/src/__tests__/utils/FetchUtil.test.ts
@@ -153,7 +153,9 @@ describe('FetchUtil', () => {
     });
 
     it('should return undefined when the request throws', async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
 
       const fetchUtil = new FetchUtil({ baseUrl });
       const result = await fetchUtil.fetchImage('/getWalletImage/1');

--- a/packages/core/src/utils/FetchUtil.ts
+++ b/packages/core/src/utils/FetchUtil.ts
@@ -81,6 +81,12 @@ export class FetchUtil {
       const url = this.createUrl({ path, params }).toString();
       const response = await fetch(url, { headers });
 
+      // Bail on non-2xx so error bodies aren't base64-encoded into a bogus data
+      // URL (RN's `Image` would silently fail instead of showing the placeholder).
+      if (!response.ok) {
+        return undefined;
+      }
+
       // React Native's `fetch(...).blob()` throws "Creating blobs from
       // 'ArrayBuffer' and 'ArrayBufferView' are not supported" for binary
       // responses, so Blob + FileReader can't be used to build the data URL
@@ -100,20 +106,22 @@ export class FetchUtil {
   private static _arrayBufferToBase64(buffer: ArrayBuffer): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
     const bytes = new Uint8Array(buffer);
-    let base64 = '';
+    const parts: string[] = [];
 
     for (let i = 0; i < bytes.length; i += 3) {
       const byte0 = bytes[i] as number;
       const byte1 = i + 1 < bytes.length ? (bytes[i + 1] as number) : 0;
       const byte2 = i + 2 < bytes.length ? (bytes[i + 2] as number) : 0;
 
-      base64 += chars[byte0 >> 2];
-      base64 += chars[((byte0 & 0x03) << 4) | (byte1 >> 4)];
-      base64 += i + 1 < bytes.length ? chars[((byte1 & 0x0f) << 2) | (byte2 >> 6)] : '=';
-      base64 += i + 2 < bytes.length ? chars[byte2 & 0x3f] : '=';
+      parts.push(chars[byte0 >> 2] as string);
+      parts.push(chars[((byte0 & 0x03) << 4) | (byte1 >> 4)] as string);
+      parts.push(
+        i + 1 < bytes.length ? (chars[((byte1 & 0x0f) << 2) | (byte2 >> 6)] as string) : '='
+      );
+      parts.push(i + 2 < bytes.length ? (chars[byte2 & 0x3f] as string) : '=');
     }
 
-    return base64;
+    return parts.join('');
   }
   /* eslint-enable no-bitwise */
 

--- a/packages/core/src/utils/FetchUtil.ts
+++ b/packages/core/src/utils/FetchUtil.ts
@@ -80,17 +80,42 @@ export class FetchUtil {
     try {
       const url = this.createUrl({ path, params }).toString();
       const response = await fetch(url, { headers });
-      const blob = await response.blob();
-      const reader = new FileReader();
-      reader.readAsDataURL(blob);
 
-      return new Promise<string>(resolve => {
-        reader.onloadend = () => resolve(reader.result as string);
-      });
+      // React Native's `fetch(...).blob()` throws "Creating blobs from
+      // 'ArrayBuffer' and 'ArrayBufferView' are not supported" for binary
+      // responses, so Blob + FileReader can't be used to build the data URL
+      // (wallet/network images would silently fail to load). Read the bytes as
+      // an ArrayBuffer and base64-encode them into a data URL instead.
+      const arrayBuffer = await response.arrayBuffer();
+      const contentType = response.headers.get('content-type') ?? 'image/png';
+
+      return `data:${contentType};base64,${FetchUtil._arrayBufferToBase64(arrayBuffer)}`;
     } catch {
       return undefined;
     }
   }
+
+  // Dependency-free base64 encoder (RN has no global `Buffer`/`btoa` guarantee).
+  /* eslint-disable no-bitwise */
+  private static _arrayBufferToBase64(buffer: ArrayBuffer): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    const bytes = new Uint8Array(buffer);
+    let base64 = '';
+
+    for (let i = 0; i < bytes.length; i += 3) {
+      const byte0 = bytes[i] as number;
+      const byte1 = i + 1 < bytes.length ? (bytes[i + 1] as number) : 0;
+      const byte2 = i + 2 < bytes.length ? (bytes[i + 2] as number) : 0;
+
+      base64 += chars[byte0 >> 2];
+      base64 += chars[((byte0 & 0x03) << 4) | (byte1 >> 4)];
+      base64 += i + 1 < bytes.length ? chars[((byte1 & 0x0f) << 2) | (byte2 >> 6)] : '=';
+      base64 += i + 2 < bytes.length ? chars[byte2 & 0x3f] : '=';
+    }
+
+    return base64;
+  }
+  /* eslint-enable no-bitwise */
 
   public createUrl({ path, params }: RequestArguments) {
     let fullUrl: string;


### PR DESCRIPTION
## Problem

Wallet and network logos in the connect modal never load on React Native — the list shows only placeholder icons on both iOS and Android (wallet **names** load fine, since those come from plain JSON).

Root cause is in `FetchUtil.fetchImage` (`packages/core/src/utils/FetchUtil.ts`), which builds the image data URL with `response.blob()` + `FileReader.readAsDataURL`:

```ts
const blob = await response.blob();      // ← throws on RN for binary bodies
const reader = new FileReader();
reader.readAsDataURL(blob);
```

On React Native, `fetch(...).blob()` for a binary (image) response throws:

> `Error: Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported`

RN's `Blob` implementation can't be constructed from an `ArrayBuffer` body, so the promise rejects, `fetchImage` returns `undefined`, and `AssetUtil.getWalletImage` falls back to the placeholder. This is the **only** `.blob()` usage in the codebase.

Observed with Expo SDK 56 / React Native 0.85.3 (New Architecture), `@reown/appkit-*@2.0.5`. The image `fetch` itself succeeds (HTTP 200, `content-type: image/webp`); only the `blob()` step fails.

## Fix

Read the response as an `ArrayBuffer` and base64-encode it into the data URL, avoiding `Blob`/`FileReader` entirely:

```ts
const arrayBuffer = await response.arrayBuffer();
const contentType = response.headers.get('content-type') ?? 'image/png';
return `data:${contentType};base64,${FetchUtil._arrayBufferToBase64(arrayBuffer)}`;
```

The base64 encoder is dependency-free — React Native guarantees neither a global `Buffer` nor `btoa`, so relying on either would be fragile for a library.

## Tests

Adds unit tests for `fetchImage` (ArrayBuffer → base64 data URL, default content-type, `blob()` not called, error → `undefined`). Full `packages/core` suite passes:

```
Tests:       17 passed, 17 total
```

## Verification

Patched into a multichain AppKit + wagmi app on Expo SDK 56 / RN 0.85.3:
- **Android**: wallet logos (Binance, MetaMask, SafePal, Trust Wallet, …) render; zero blob errors.
- **iOS**: zero blob errors after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)